### PR TITLE
Add catch-all handlers, built-in logging, and PostToolUse improvements

### DIFF
--- a/src/fasthooks/blueprint.py
+++ b/src/fasthooks/blueprint.py
@@ -36,17 +36,25 @@ class Blueprint:
         self._lifecycle_handlers: dict[str, list[tuple[Callable, Callable | None]]] = defaultdict(list)
 
     def pre_tool(self, *tools: str, when: Callable | None = None) -> Callable:
-        """Decorator to register a PreToolUse handler."""
+        """Decorator to register a PreToolUse handler.
+
+        If no tools specified, registers as catch-all for ALL tools.
+        """
         def decorator(func: Callable) -> Callable:
-            for tool in tools:
+            targets = tools if tools else ("*",)
+            for tool in targets:
                 self._pre_tool_handlers[tool].append((func, when))
             return func
         return decorator
 
     def post_tool(self, *tools: str, when: Callable | None = None) -> Callable:
-        """Decorator to register a PostToolUse handler."""
+        """Decorator to register a PostToolUse handler.
+
+        If no tools specified, registers as catch-all for ALL tools.
+        """
         def decorator(func: Callable) -> Callable:
-            for tool in tools:
+            targets = tools if tools else ("*",)
+            for tool in targets:
                 self._post_tool_handlers[tool].append((func, when))
             return func
         return decorator

--- a/src/fasthooks/depends/state.py
+++ b/src/fasthooks/depends/state.py
@@ -58,3 +58,23 @@ class State(dict):
         state_dir = Path(state_dir)
         state_file = state_dir / f"{session_id}.json"
         return cls(state_file)
+
+
+class NullState(dict):
+    """No-op state that doesn't persist.
+
+    Used when no state_dir is configured. Behaves like dict
+    but save() does nothing.
+    """
+
+    def save(self) -> None:
+        """No-op save."""
+        pass
+
+    def __enter__(self) -> "NullState":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit - no-op."""
+        pass

--- a/src/fasthooks/events/tools.py
+++ b/src/fasthooks/events/tools.py
@@ -14,6 +14,7 @@ class ToolEvent(BaseEvent):
     tool_name: str
     tool_input: dict
     tool_use_id: str
+    tool_response: dict | None = None  # Only populated for PostToolUse events
 
 
 class Bash(ToolEvent):
@@ -162,6 +163,25 @@ class Task(ToolEvent):
     def run_in_background(self) -> bool | None:
         """Whether to run in background."""
         return self.tool_input.get("run_in_background")
+
+    @property
+    def agent_id(self) -> str | None:
+        """Agent ID from PostToolUse response."""
+        if self.tool_response:
+            return self.tool_response.get("agentId")
+        return None
+
+    @property
+    def response_text(self) -> str:
+        """Extract text content from Task response (PostToolUse only)."""
+        if not self.tool_response:
+            return ""
+        content = self.tool_response.get("content", [])
+        texts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                texts.append(block.get("text", ""))
+        return "\n".join(texts)
 
 
 class WebSearch(ToolEvent):

--- a/src/fasthooks/logging.py
+++ b/src/fasthooks/logging.py
@@ -1,0 +1,127 @@
+"""Built-in JSONL logging for fasthooks."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class EventLogger:
+    """JSONL event logger that writes to session-specific files.
+
+    Logs all hook events to `{log_dir}/hooks-{session_id}.jsonl`
+    and maintains a `latest.jsonl` symlink.
+    """
+
+    def __init__(self, log_dir: str | Path):
+        """Initialize EventLogger.
+
+        Args:
+            log_dir: Directory to write log files
+        """
+        self.log_dir = Path(log_dir)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+    def log(self, data: dict[str, Any]) -> None:
+        """Log an event to the appropriate session file.
+
+        Args:
+            data: Raw hook input data
+        """
+        session_id = data.get("session_id", "unknown")
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Build log entry
+        entry = self._build_entry(data, ts)
+
+        # Write to session file
+        session_file = self.log_dir / f"hooks-{session_id}.jsonl"
+        with open(session_file, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+
+        # Update latest.jsonl symlink
+        self._update_symlink(session_id)
+
+    def _build_entry(self, data: dict[str, Any], ts: str) -> dict[str, Any]:
+        """Build a log entry with flattened fields.
+
+        Args:
+            data: Raw hook input data
+            ts: Timestamp string
+
+        Returns:
+            Flattened log entry dict
+        """
+        event = data.get("hook_event_name", "unknown")
+        tool_name = data.get("tool_name")
+        tool_input = data.get("tool_input", {})
+
+        entry: dict[str, Any] = {
+            "ts": ts,
+            "session_id": data.get("session_id"),
+            "event": event,
+            "cwd": data.get("cwd"),
+            "permission_mode": data.get("permission_mode"),
+        }
+
+        # Tool events
+        if tool_name:
+            entry["tool_name"] = tool_name
+            entry["tool_input"] = tool_input
+
+            # Flatten tool-specific fields for easier querying
+            if tool_name == "Bash":
+                entry["bash_command"] = tool_input.get("command")
+                entry["bash_description"] = tool_input.get("description")
+            elif tool_name in ("Write", "Edit", "Read"):
+                entry["file_path"] = tool_input.get("file_path")
+            elif tool_name == "Grep":
+                entry["grep_pattern"] = tool_input.get("pattern")
+            elif tool_name == "Glob":
+                entry["glob_pattern"] = tool_input.get("pattern")
+            elif tool_name == "Task":
+                entry["subagent_type"] = tool_input.get("subagent_type")
+                entry["subagent_model"] = tool_input.get("model")
+            elif tool_name == "WebSearch":
+                entry["search_query"] = tool_input.get("query")
+            elif tool_name == "WebFetch":
+                entry["fetch_url"] = tool_input.get("url")
+
+        # Tool response (PostToolUse)
+        if data.get("tool_response"):
+            entry["tool_response"] = data["tool_response"]
+            # Extract agent_id for Task tool
+            if tool_name == "Task":
+                entry["agent_id"] = data["tool_response"].get("agentId")
+
+        # Lifecycle event fields
+        if event == "UserPromptSubmit":
+            entry["prompt"] = data.get("prompt")
+        elif event == "Stop":
+            entry["stop_hook_active"] = data.get("stop_hook_active")
+        elif event == "SubagentStop":
+            entry["agent_id"] = data.get("agent_id")
+            entry["stop_hook_active"] = data.get("stop_hook_active")
+        elif event == "SessionStart":
+            entry["source"] = data.get("source")
+            entry["transcript_path"] = data.get("transcript_path")
+        elif event == "SessionEnd":
+            entry["reason"] = data.get("reason")
+        elif event == "PreCompact":
+            entry["trigger"] = data.get("trigger")
+        elif event == "Notification":
+            entry["message"] = data.get("message")
+            entry["notification_type"] = data.get("notification_type")
+
+        # Remove None values
+        return {k: v for k, v in entry.items() if v is not None}
+
+    def _update_symlink(self, session_id: str) -> None:
+        """Update latest.jsonl symlink to current session file."""
+        latest = self.log_dir / "latest.jsonl"
+        try:
+            latest.unlink(missing_ok=True)
+            latest.symlink_to(f"hooks-{session_id}.jsonl")
+        except OSError:
+            pass  # Best effort


### PR DESCRIPTION
## Summary

- **Catch-all handler support**: `@app.pre_tool()` with no args matches ALL tools (same for `post_tool`)
- **Built-in JSONL logging**: `HookApp(log_dir=...)` automatically logs all events before dispatch
- **tool_response field**: `ToolEvent` now includes `tool_response` for PostToolUse events
- **Task improvements**: Added `agent_id` and `response_text` properties for subagent tracking
- **NullState fix**: Prevents crash when `state_dir` not configured

## Example Usage

```python
from fasthooks import HookApp, allow, deny

# Built-in logging enabled
app = HookApp(log_dir="hooks/logs")

# Catch-all handler - runs for ALL tools
@app.pre_tool()
def log_all_tools(event):
    print(f"Tool: {event.tool_name}")

# Tool-specific handler
@app.pre_tool("Bash")
def check_bash(event):
    if "rm -rf" in event.command:
        return deny("Dangerous command")
```

## Test plan

- [x] All 126 existing tests pass
- [x] Added 3 new tests for catch-all behavior
- [x] Manual testing with Claude Code hooks