### PR TITLE
Add async handler support with anyio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+    "anyio>=4.0",
     "pydantic>=2.0",
     "rich>=13.0",
     "typer>=0.9.0",

--- a/src/fasthooks/testing/client.py
+++ b/src/fasthooks/testing/client.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import anyio
+
 from fasthooks.events.base import BaseEvent
 from fasthooks.responses import HookResponse
 
@@ -46,7 +48,7 @@ class TestClient:
         """
         # Convert event to dict for dispatch
         data = event.model_dump()
-        return self.app._dispatch(data)
+        return anyio.run(self.app._dispatch, data)
 
     def send_raw(self, data: dict[str, Any]) -> HookResponse | None:
         """Send raw event data to the app.
@@ -57,4 +59,4 @@ class TestClient:
         Returns:
             HookResponse if deny/block, None if allowed
         """
-        return self.app._dispatch(data)
+        return anyio.run(self.app._dispatch, data)

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -129,6 +142,7 @@ name = "fasthooks"
 version = "0.1.2"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "typer" },
@@ -145,6 +159,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "typer", specifier = ">=0.9.0" },
@@ -157,6 +172,15 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.9" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `anyio>=4.0` dependency for async runtime
- Convert internal dispatch to async (`_dispatch`, `_run_handlers`, `_run_with_middleware`)
- Keep `run()` sync, bridge via `anyio.run()`
- Sync handlers run in threadpool (non-blocking for IO-heavy ops)
- Async handlers awaited directly
- Support async guards and async middleware
- Sync middleware gets sync `call_next` that bridges back to async

## Usage
```python
@app.pre_tool("Bash")
async def async_check(event):
    result = await external_api_call()
    if result.blocked:
        return deny(result.reason)

# Async guard
async def is_dangerous(event):
    return "rm" in event.command

@app.pre_tool("Bash", when=is_dangerous)
async def block_dangerous(event):
    return deny("dangerous")

# Async middleware
@app.middleware
async def timing(event, call_next):
    start = time.time()
    response = await call_next(event)
    return response
```

## Test plan
- [x] Existing tests pass (134 tests)
- [x] New async handler tests added
- [x] Async guard tests
- [x] Async middleware tests
- [x] Mixed sync/async tests