### PR TITLE
Add PermissionRequest typed event and response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,17 @@ Add to your `settings.json`:
 ### Responses
 
 ```python
-from fasthooks import allow, deny, block
+from fasthooks import allow, deny, block, approve_permission, deny_permission
 
 return allow()                              # Proceed
 return allow(message="Approved by hook")    # With message
 return deny("Reason shown to Claude")       # Block tool
 return block("Continue working on X")       # For Stop hooks
+
+# For PermissionRequest hooks
+return approve_permission()                 # Auto-approve permission
+return approve_permission(modify={"command": "safe"})  # Approve with modified input
+return deny_permission("Not allowed")       # Deny permission
 ```
 
 ### Tool Decorators
@@ -120,6 +125,8 @@ return block("Continue working on X")       # For Stop hooks
 @app.on_pre_compact()                    # Before compaction
 @app.on_prompt()                         # User submits prompt
 @app.on_notification()                   # Notification sent
+@app.on_permission("Bash")               # Permission dialog shown (tool-specific)
+@app.on_permission()                     # Permission dialog (catch-all)
 ```
 
 ### Typed Events

--- a/src/fasthooks/__init__.py
+++ b/src/fasthooks/__init__.py
@@ -1,13 +1,24 @@
 """cchooks - Delightful Claude Code hooks."""
 from fasthooks.app import HookApp
 from fasthooks.blueprint import Blueprint
-from fasthooks.responses import HookResponse, allow, block, deny
+from fasthooks.responses import (
+    HookResponse,
+    PermissionHookResponse,
+    allow,
+    approve_permission,
+    block,
+    deny,
+    deny_permission,
+)
 
 __all__ = [
     "Blueprint",
     "HookApp",
     "HookResponse",
+    "PermissionHookResponse",
     "allow",
+    "approve_permission",
     "block",
     "deny",
+    "deny_permission",
 ]

--- a/src/fasthooks/_internal/io.py
+++ b/src/fasthooks/_internal/io.py
@@ -5,7 +5,7 @@ import json
 import sys
 from typing import IO, Any, cast
 
-from fasthooks.responses import HookResponse
+from fasthooks.responses import HookResponse, PermissionHookResponse
 
 
 def read_stdin(stdin: IO[str] | None = None) -> dict[str, Any]:
@@ -29,11 +29,13 @@ def read_stdin(stdin: IO[str] | None = None) -> dict[str, Any]:
         return {}
 
 
-def write_stdout(response: HookResponse, stdout: IO[str] | None = None) -> None:
-    """Write HookResponse JSON to stdout.
+def write_stdout(
+    response: HookResponse | PermissionHookResponse, stdout: IO[str] | None = None
+) -> None:
+    """Write hook response JSON to stdout.
 
     Args:
-        response: The response to write
+        response: The response to write (HookResponse or PermissionHookResponse)
         stdout: Output stream, defaults to sys.stdout
     """
     if stdout is None:

--- a/src/fasthooks/testing/client.py
+++ b/src/fasthooks/testing/client.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 
 from fasthooks.events.base import BaseEvent
-from fasthooks.responses import HookResponse
+from fasthooks.responses import HookResponse, PermissionHookResponse
 
 if TYPE_CHECKING:
     from fasthooks.app import HookApp
@@ -37,26 +37,28 @@ class TestClient:
         """
         self.app = app
 
-    def send(self, event: BaseEvent) -> HookResponse | None:
+    def send(self, event: BaseEvent) -> HookResponse | PermissionHookResponse | None:
         """Send an event to the app and return the response.
 
         Args:
             event: Typed event (from MockEvent or manual)
 
         Returns:
-            HookResponse if deny/block, None if allowed
+            HookResponse/PermissionHookResponse if actionable, None if pass-through
         """
         # Convert event to dict for dispatch
         data = event.model_dump()
         return anyio.run(self.app._dispatch, data)
 
-    def send_raw(self, data: dict[str, Any]) -> HookResponse | None:
+    def send_raw(
+        self, data: dict[str, Any]
+    ) -> HookResponse | PermissionHookResponse | None:
         """Send raw event data to the app.
 
         Args:
             data: Raw event dict (as Claude Code would send)
 
         Returns:
-            HookResponse if deny/block, None if allowed
+            HookResponse/PermissionHookResponse if actionable, None if pass-through
         """
         return anyio.run(self.app._dispatch, data)

--- a/src/fasthooks/testing/mocks.py
+++ b/src/fasthooks/testing/mocks.py
@@ -150,3 +150,73 @@ class MockEvent:
             hook_event_name="PreCompact",
             trigger=trigger,
         )
+
+    # ═══════════════════════════════════════════════════════════════════════════
+    # PermissionRequest events
+    # ═══════════════════════════════════════════════════════════════════════════
+
+    @staticmethod
+    def permission_bash(
+        command: str,
+        *,
+        description: str | None = None,
+        session_id: str = "test-session",
+        cwd: str = "/workspace",
+    ) -> Bash:
+        """Create a Bash PermissionRequest event."""
+        tool_input: dict[str, Any] = {"command": command}
+        if description:
+            tool_input["description"] = description
+
+        return Bash(
+            session_id=session_id,
+            cwd=cwd,
+            permission_mode="default",
+            hook_event_name="PermissionRequest",
+            tool_name="Bash",
+            tool_input=tool_input,
+            tool_use_id="test-tool-use",
+        )
+
+    @staticmethod
+    def permission_write(
+        file_path: str,
+        content: str = "",
+        *,
+        session_id: str = "test-session",
+        cwd: str = "/workspace",
+    ) -> Write:
+        """Create a Write PermissionRequest event."""
+        return Write(
+            session_id=session_id,
+            cwd=cwd,
+            permission_mode="default",
+            hook_event_name="PermissionRequest",
+            tool_name="Write",
+            tool_input={"file_path": file_path, "content": content},
+            tool_use_id="test-tool-use",
+        )
+
+    @staticmethod
+    def permission_edit(
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        *,
+        session_id: str = "test-session",
+        cwd: str = "/workspace",
+    ) -> Edit:
+        """Create an Edit PermissionRequest event."""
+        return Edit(
+            session_id=session_id,
+            cwd=cwd,
+            permission_mode="default",
+            hook_event_name="PermissionRequest",
+            tool_name="Edit",
+            tool_input={
+                "file_path": file_path,
+                "old_string": old_string,
+                "new_string": new_string,
+            },
+            tool_use_id="test-tool-use",
+        )

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,7 +1,7 @@
 """Tests for response builders."""
 import json
 
-from fasthooks import allow, block, deny
+from fasthooks import allow, approve_permission, block, deny, deny_permission
 
 
 class TestAllow:
@@ -69,3 +69,63 @@ class TestBlock:
         data = json.loads(response.to_json())
         assert data["decision"] == "block"
         assert data["reason"] == "Not done yet"
+
+
+class TestApprovePermission:
+    def test_approve_permission_basic(self):
+        """approve_permission() returns allow behavior."""
+        response = approve_permission()
+        assert response.behavior == "allow"
+
+    def test_approve_permission_with_modify(self):
+        """approve_permission(modify=...) includes updated input."""
+        response = approve_permission(modify={"command": "ls -la"})
+        assert response.behavior == "allow"
+        assert response.modify == {"command": "ls -la"}
+
+    def test_approve_permission_to_json(self):
+        """approve_permission() produces correct JSON."""
+        response = approve_permission()
+        data = json.loads(response.to_json())
+        assert data["hookSpecificOutput"]["hookEventName"] == "PermissionRequest"
+        assert data["hookSpecificOutput"]["decision"]["behavior"] == "allow"
+
+    def test_approve_permission_to_json_with_modify(self):
+        """approve_permission(modify=...) includes updatedInput in JSON."""
+        response = approve_permission(modify={"command": "echo safe"})
+        data = json.loads(response.to_json())
+        assert data["hookSpecificOutput"]["decision"]["updatedInput"] == {"command": "echo safe"}
+
+
+class TestDenyPermission:
+    def test_deny_permission_basic(self):
+        """deny_permission() returns deny behavior."""
+        response = deny_permission("Not allowed")
+        assert response.behavior == "deny"
+        assert response.message == "Not allowed"
+
+    def test_deny_permission_with_interrupt(self):
+        """deny_permission(interrupt=True) stops Claude entirely."""
+        response = deny_permission("Critical error", interrupt=True)
+        assert response.behavior == "deny"
+        assert response.interrupt is True
+
+    def test_deny_permission_no_message(self):
+        """deny_permission() works without message."""
+        response = deny_permission()
+        assert response.behavior == "deny"
+        assert response.message is None
+
+    def test_deny_permission_to_json(self):
+        """deny_permission() produces correct JSON."""
+        response = deny_permission("Blocked")
+        data = json.loads(response.to_json())
+        assert data["hookSpecificOutput"]["hookEventName"] == "PermissionRequest"
+        assert data["hookSpecificOutput"]["decision"]["behavior"] == "deny"
+        assert data["hookSpecificOutput"]["decision"]["message"] == "Blocked"
+
+    def test_deny_permission_to_json_with_interrupt(self):
+        """deny_permission(interrupt=True) includes interrupt in JSON."""
+        response = deny_permission("Stop!", interrupt=True)
+        data = json.loads(response.to_json())
+        assert data["hookSpecificOutput"]["decision"]["interrupt"] is True


### PR DESCRIPTION
## Summary
- Add `PermissionHookResponse` class with `approve_permission()` / `deny_permission()` builders
- Update `on_permission()` decorator to accept tool names like `@app.on_permission("Bash")`
- Route PermissionRequest through typed tool events (reuses Bash, Write, etc. for typed accessors)
- Add `MockEvent.permission_bash/write/edit()` test factories
- Add 11 tests for PermissionRequest handling

## Usage
```python
@app.on_permission("Bash")
def auto_approve_safe(event):
    if "rm -rf" in event.command:
        return deny_permission("Dangerous command")
    return approve_permission()

@app.on_permission()  # catch-all
def log_all_permissions(event):
    print(f"Permission request for {event.tool_name}")
    return approve_permission()
```

## Test plan
- [x] `make check` passes (lint, typecheck, 153 tests)
- [x] New tests for approve/deny responses
- [x] New tests for on_permission decorator with tool matching
- [x] New tests for catch-all, guards, async handlers

Closes #4