### PR TITLE
Refactor: Extract BaseHookResponse for cleaner type signatures

### DIFF
--- a/src/fasthooks/__init__.py
+++ b/src/fasthooks/__init__.py
@@ -2,6 +2,7 @@
 from fasthooks.app import HookApp
 from fasthooks.blueprint import Blueprint
 from fasthooks.responses import (
+    BaseHookResponse,
     HookResponse,
     PermissionHookResponse,
     allow,
@@ -12,6 +13,7 @@ from fasthooks.responses import (
 )
 
 __all__ = [
+    "BaseHookResponse",
     "Blueprint",
     "HookApp",
     "HookResponse",

--- a/src/fasthooks/_internal/io.py
+++ b/src/fasthooks/_internal/io.py
@@ -5,7 +5,7 @@ import json
 import sys
 from typing import IO, Any, cast
 
-from fasthooks.responses import HookResponse, PermissionHookResponse
+from fasthooks.responses import BaseHookResponse
 
 
 def read_stdin(stdin: IO[str] | None = None) -> dict[str, Any]:
@@ -29,13 +29,11 @@ def read_stdin(stdin: IO[str] | None = None) -> dict[str, Any]:
         return {}
 
 
-def write_stdout(
-    response: HookResponse | PermissionHookResponse, stdout: IO[str] | None = None
-) -> None:
+def write_stdout(response: BaseHookResponse, stdout: IO[str] | None = None) -> None:
     """Write hook response JSON to stdout.
 
     Args:
-        response: The response to write (HookResponse or PermissionHookResponse)
+        response: The response to write
         stdout: Output stream, defaults to sys.stdout
     """
     if stdout is None:

--- a/src/fasthooks/testing/client.py
+++ b/src/fasthooks/testing/client.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 
 from fasthooks.events.base import BaseEvent
-from fasthooks.responses import HookResponse, PermissionHookResponse
+from fasthooks.responses import BaseHookResponse
 
 if TYPE_CHECKING:
     from fasthooks.app import HookApp
@@ -37,28 +37,26 @@ class TestClient:
         """
         self.app = app
 
-    def send(self, event: BaseEvent) -> HookResponse | PermissionHookResponse | None:
+    def send(self, event: BaseEvent) -> BaseHookResponse | None:
         """Send an event to the app and return the response.
 
         Args:
             event: Typed event (from MockEvent or manual)
 
         Returns:
-            HookResponse/PermissionHookResponse if actionable, None if pass-through
+            BaseHookResponse if actionable, None if pass-through
         """
         # Convert event to dict for dispatch
         data = event.model_dump()
         return anyio.run(self.app._dispatch, data)
 
-    def send_raw(
-        self, data: dict[str, Any]
-    ) -> HookResponse | PermissionHookResponse | None:
+    def send_raw(self, data: dict[str, Any]) -> BaseHookResponse | None:
         """Send raw event data to the app.
 
         Args:
             data: Raw event dict (as Claude Code would send)
 
         Returns:
-            HookResponse/PermissionHookResponse if actionable, None if pass-through
+            BaseHookResponse if actionable, None if pass-through
         """
         return anyio.run(self.app._dispatch, data)


### PR DESCRIPTION
## Summary
- Add `BaseHookResponse` ABC with `to_json()` and `should_return()` methods
- `HookResponse.should_return()` returns True only for deny/block
- `PermissionHookResponse` inherits default `should_return()` (always True)
- Simplify `_run_handlers`: no more `isinstance` checks
- Clean type signatures: `BaseHookResponse | None` everywhere

## Before
```python
Callable[[BaseEvent], Coroutine[Any, Any, HookResponse | PermissionHookResponse | None]]

# In _run_handlers:
if isinstance(response, PermissionHookResponse):
    return response
elif response.decision in ("deny", "block"):
    return response
```

## After
```python
Callable[[BaseEvent], Coroutine[Any, Any, BaseHookResponse | None]]

# In _run_handlers:
if response and response.should_return():
    return response
```

## Test plan
- [x] `make check` passes (lint, typecheck, 153 tests)
- [x] All existing tests continue to pass

Closes #11