### PR TITLE
Add CLI improvements: --input flag, settings.json generation, example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,12 @@ fasthooks init my-hooks
 # Run hooks (called by Claude Code)
 fasthooks run hooks.py
 
-# Test hooks locally with a JSON file
-fasthooks run hooks.py --input test_event.json
+# Generate sample event JSON for testing
+fasthooks example bash
+fasthooks example bash_dangerous > event.json
+
+# Test hooks locally
+fasthooks run hooks.py --input event.json
 
 # Show help
 fasthooks --help


### PR DESCRIPTION
## Summary
- `fasthooks run --input file.json` - test hooks locally without Claude Code
- `fasthooks init` now generates `.claude/settings.json` with full hook config
- `fasthooks example <type>` - generate sample event JSON for testing
- hooks.py template now includes inline script dependencies for `uv run`

## Testing workflow
```bash
fasthooks example bash_dangerous > event.json
fasthooks run hooks.py --input event.json
# Output: {"decision": "deny", "reason": "..."}
```

## Test plan
- [x] `fasthooks run --input` works with JSON files
- [x] `fasthooks init` creates .claude/settings.json
- [x] `fasthooks example` generates valid JSON for all event types
- [x] All 153 tests pass
- [x] Lint/typecheck clean

Partial fix for #3