### PR TITLE
DevX ergonomics pass: SMELL.md tracker + fail-mode safety fix, typed custom tools, response docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,22 +115,39 @@ Use `--scope user|local` to install elsewhere, and `fasthooks uninstall` to remo
 
 ### Responses
 
+A handler returns a response to influence Claude Code, or returns nothing to
+stay out of the way.
+
 ```python
 from fasthooks import allow, deny, block, approve_permission, deny_permission
 
-return allow()                              # Proceed
-return allow(message="Approved by hook")    # With message
-return deny("Reason shown to Claude")       # Block tool
-return block("Continue working on X")       # For Stop hooks
+return None                                 # Pass / no opinion (the common case)
+return deny("Reason shown to Claude")       # Block a tool (PreToolUse)
+return block("Continue working on X")       # Don't stop yet (Stop/SubagentStop)
 
-# For PermissionRequest hooks
-return approve_permission()                 # Auto-approve permission
-return approve_permission(modify={"command": "safe"})  # Approve with modified input
-return deny_permission("Not allowed")       # Deny permission
+return allow()                              # Same as `return None` (no-op)
+return allow(message="note")                # Allow, but show a message
+return allow(modify={"command": "safe ls"}) # Allow with rewritten tool input
 
-# For SessionStart / UserPromptSubmit - inject text into Claude's context
+# PermissionRequest hooks (a *different* response shape — see below)
+return approve_permission()                 # Allow the permission
+return approve_permission(modify={"command": "safe"})
+return deny_permission("Not allowed")       # Deny the permission
+
+# SessionStart / UserPromptSubmit - inject text into Claude's context
 return context("Project uses Python 3.12", hook_event="SessionStart")
 ```
+
+**`return None` vs `allow()`** — they're equivalent for a bare allow: both mean
+"no opinion, proceed." The idiomatic guard just returns nothing (or `deny(...)`).
+Reach for `allow(...)` only when you want to *attach* something — a `message`, or
+a `modify` that rewrites the tool input before it runs.
+
+**`allow()` vs `approve_permission()`** — same intent ("let it proceed"), two
+different hook shapes. Regular tool hooks (`PreToolUse`, …) use `allow`/`deny`;
+the separate `PermissionRequest` hook uses `approve_permission`/`deny_permission`.
+The verbs differ because Claude Code's protocol uses a different field vocabulary
+for each — fasthooks mirrors the wire shapes rather than papering over them.
 
 ### Tool Decorators
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,25 @@ def startup_only(event):
     pass
 ```
 
+### Fail mode (what happens when a handler crashes)
+
+By default fasthooks **fails open** — if a handler raises, the error is logged and
+the action proceeds. For a security guard you usually want the opposite: a crash
+should **block**, not silently allow.
+
+```python
+app = HookApp(fail_mode="closed")          # app-wide default
+
+@app.pre_tool("Bash", fail_mode="closed")  # or per-handler
+def guard(event):
+    ...
+```
+
+When `closed`, a crashed handler denies/blocks the event it was handling
+(PreToolUse → deny, PermissionRequest → deny, Stop/SubagentStop/PostToolUse →
+block). Events with no block semantics (SessionStart, Notification, …) always
+fail open. Strategies declare their own `fail_mode` via `Meta`.
+
 ### Blueprints
 
 ```python

--- a/README.md
+++ b/README.md
@@ -192,6 +192,44 @@ def on_bash_failure(event):
     ...
 ```
 
+### Custom & MCP tools
+
+Typed accessors (`event.command`, `event.file_path`) exist for the built-in
+tools. **Any other tool — including MCP tools — works too, via `event.tool_input`:**
+
+```python
+@app.pre_tool("mcp__server__search")
+def guard(event):
+    query = event.tool_input.get("query", "")   # always available, any tool
+    if "secret" in query:
+        return deny("No.")
+```
+
+That's the only thing you need. If you hook a custom tool *often* and want the
+same typed-accessor / autocomplete experience as the built-ins, register a
+`ToolEvent` subclass (opt-in — one registration covers pre/post/permission):
+
+```python
+from fasthooks import ToolEvent
+
+class Search(ToolEvent):
+    @property
+    def query(self) -> str:
+        return self.tool_input.get("query", "")
+
+app.register_tool_event("mcp__server__search", Search)
+
+@app.pre_tool("mcp__server__search")
+def guard(event):           # event is a Search
+    if "secret" in event.query:
+        return deny("No.")
+```
+
+The payoff (autocomplete) costs one `@property` per field. Expose fields via
+`@property` over `self.tool_input` and don't add **required** pydantic fields:
+event parsing happens before your handler runs, so a validation error on a
+missing field would fail *open* (allow) even under `fail_mode="closed"`.
+
 ### Dependency Injection
 
 ```python

--- a/SMELL.md
+++ b/SMELL.md
@@ -68,18 +68,39 @@ fix direction. Status: `open` → `in-progress` → `done` (link the commit/PR).
 
 ---
 
-## S2 — "Typed events" is partial and the fallback is silent about it
+## S2 — "Typed events" is partial and the fallback is undocumented
 **Severity:** medium
-**Status:** open
+**Status:** done — branch `devx/smell-tracking`
 
 **Evidence:**
 - ~10 built-in tools have typed accessors (`events/tools.py`); **any custom or MCP
   tool falls back to bare `ToolEvent`** with no accessors —
-  `app.py:648` `TOOL_EVENT_MAP.get(tool_name, ToolEvent)`. Author silently drops to
-  `event.tool_input.get("...")`, no autocomplete, no signal they left the typed path.
+  `app.py` `TOOL_EVENT_MAP.get(tool_name, ToolEvent)`. The author must know to use
+  `event.tool_input`; accessing a non-modeled field (`event.query`) raises
+  `AttributeError` (verified — *not* a silent `None`, so the gap is discoverability
+  + no autocomplete, not wrong values).
 
-**Fix direction:** document the fallback explicitly; consider a typed `.input` helper
-or a way to register accessors for custom/MCP tools.
+**Resolution (done):**
+- **Docs first** (the diagnosed gap was discoverability): README "Custom & MCP tools"
+  leads with "`event.tool_input` always works for any tool," then presents the opt-in.
+- **Opt-in mechanism:** `app.register_tool_event(name, ToolEventSubclass)` — per-app
+  (no global mutation / test leakage), validates the subclass (fast-fail TypeError),
+  one registration covers pre/post/permission. Resolution order in
+  `_parse_tool_event`: per-app override → built-in map → bare ToolEvent.
+- Exported `ToolEvent`, `HookEventName`, `GenericEvent` at top level for ergonomic
+  subclassing/import.
+- **Documented constraint (cross-feature interaction):** custom event classes must be
+  `@property`-only and keep `extra="allow"` — a *required* pydantic field would make
+  parsing (which runs in `_dispatch`, *outside* `_run_handlers`) fail **open** on a
+  missing field, punching a hole through `fail_mode="closed"`. Same interaction class
+  as the S3 guard-raise bug.
+- 5 tests in `tests/test_tool_event_registration.py` (typed pre + post, bare fallback
+  + AttributeError, subclass validation, per-app isolation).
+
+**Not done (deliberately):** the built-in `tools.py` accessors are still a hand-maintained
+`@property` wall; registration pushes that same boilerplate onto custom-tool authors.
+Acceptable (it's the durable pattern, opt-in) but a future ticket could explore a
+schema-driven accessor generator.
 
 ---
 

--- a/SMELL.md
+++ b/SMELL.md
@@ -106,7 +106,7 @@ schema-driven accessor generator.
 
 ## S1 — "Yes" has three faces and one verb flips
 **Severity:** low (mostly docs — the split is protocol-inherited, not fasthooks' invention)
-**Status:** open
+**Status:** done — branch `devx/smell-tracking`
 
 **Evidence:**
 - `allow()` → decision `"approve"`; `return None` also allows; permission requests use
@@ -120,6 +120,13 @@ schema-driven accessor generator.
 **Fix direction:** docs only — say *when* to use `return None` vs `allow()`, and that
 `allow()`/`approve_permission()` are the same intent across two protocol shapes. Do
 NOT rename builders. Tracked alongside issue #26 (observability vocabulary unification).
+
+**Resolution (done):** README "Responses" section rewritten. Verified empirically
+that a bare `allow()` is dispatch-equivalent to `return None` (both non-blocking, no
+output). Added: "`return None` vs `allow()`" (equivalent for bare allow; reach for
+`allow(...)` only to attach a `message`/`modify`) and "`allow()` vs
+`approve_permission()`" (same intent, two protocol shapes — regular tool hooks vs the
+separate PermissionRequest hook; verbs mirror the wire vocabulary). No code change.
 
 ---
 

--- a/SMELL.md
+++ b/SMELL.md
@@ -50,8 +50,18 @@ fix direction. Status: `open` → `in-progress` → `done` (link the commit/PR).
 - Strategy `Meta.fail_mode` tagged onto the handler wrapper (`base.py`), so
   `CleanStateStrategy`'s "closed" now actually blocks. Strategy mode is
   authoritative over the app default for its own handlers.
-- 11 behavior tests in `tests/test_fail_mode.py` (incl. DI-miss → deny, and
-  non-blocking-event → stays open).
+- **Guards fail open even in closed mode.** A `when=` guard is a filter, not the
+  safety check — guard evaluation is in its own try/except that always skips the
+  handler on error (only the handler *body* honors fail_mode). Caught in review:
+  without this, a field-based guard raising on a `GenericEvent` payload would
+  block the tool.
+- **Event names are now a `HookEventName(str, Enum)`** (`events/base.py`) instead
+  of scattered `"PreToolUse"` literals; used across dispatch (`tool_dicts`,
+  `event_classes`, `_fail_closed_response`). str-subclass → drop-in with the raw
+  wire strings as dict keys / in comparisons. (Tool *names* like "Bash" stay
+  strings — open-ended set incl. MCP tools.)
+- 13 behavior tests in `tests/test_fail_mode.py` (incl. DI-miss → deny,
+  non-blocking-event → stays open, guard-raise → skip-not-block).
 - **Known limitation:** per-handler mode is stashed as a function attribute, so
   registering the *same function object* under two `fail_mode`s lets the last win.
   Rare; documented. Lifting it would mean carrying mode in the `HandlerEntry` tuple.

--- a/SMELL.md
+++ b/SMELL.md
@@ -1,0 +1,83 @@
+# SMELL.md — fasthooks DevX ergonomics tracker
+
+Living list of authoring-surface friction and smells, with status. Companion to
+`REVIEW-devx.md` (which is the strategic/revival lens); this file is the focused
+**authoring ergonomics** lens: how easy is it to write a correct hook, and what
+bites you on the unhappy path.
+
+Convention: each item has an ID, severity, status, evidence (`file:line`), and the
+fix direction. Status: `open` → `in-progress` → `done` (link the commit/PR).
+
+---
+
+## S3 — Fail-open is invisible, unconfigurable for plain handlers, and `fail_mode="closed"` is a broken promise
+**Severity:** high (this is a *guardrail* library; a crashed security hook silently allowing the tool is the scariest possible default)
+**Status:** in-progress
+
+**Evidence:**
+- A raising handler (incl. a DI miss → `TypeError`) is caught, logged to stderr,
+  emitted as a `handler_error` event, and **the tool proceeds** — unconditionally.
+  `src/fasthooks/app.py:851-868` (`_run_handlers`), `app.py:535` (serve path).
+- `fail_mode: Literal["open","closed"]` exists on `StrategyMeta`
+  (`strategies/base.py:45`) and is set by strategies (`clean_state.py:49`
+  `fail_mode = "closed"  # Block if strategy errors - safety first`), but **`app.py`
+  never references `fail_mode`** — it is never enforced. The strategy wrapper just
+  re-raises (`base.py:253`) into the app's unconditional fail-open.
+- Tests only assert the *declaration* (`meta.fail_mode == "closed"`,
+  `tests/strategies/test_clean_state.py:234`), never the *behavior*. So the broken
+  promise is untested.
+- A plain `@app.pre_tool` guard has **no knob at all** to opt into fail-closed.
+
+**Fix direction:**
+1. Enforce `fail_mode` in dispatch: on a blocking-capable event (PreToolUse /
+   PermissionRequest), a `closed` handler that raises returns `deny(...)` instead of
+   silently continuing. Non-blocking events (Stop, lifecycle) stay fail-open — nothing
+   to block — but still log/emit.
+2. Expose the knob to plain handlers: app-level default (`HookApp(fail_mode=...)`)
+   + per-decorator override (`@app.pre_tool("Bash", fail_mode="closed")`). Default
+   stays `open` (backward compatible).
+3. Propagate a strategy's `Meta.fail_mode` to its handlers when included, so
+   `CleanStateStrategy` actually blocks on error.
+4. Test **behavior**, not declaration: exception → deny when closed, → allow when open.
+
+---
+
+## S2 — "Typed events" is partial and the fallback is silent about it
+**Severity:** medium
+**Status:** open
+
+**Evidence:**
+- ~10 built-in tools have typed accessors (`events/tools.py`); **any custom or MCP
+  tool falls back to bare `ToolEvent`** with no accessors —
+  `app.py:648` `TOOL_EVENT_MAP.get(tool_name, ToolEvent)`. Author silently drops to
+  `event.tool_input.get("...")`, no autocomplete, no signal they left the typed path.
+
+**Fix direction:** document the fallback explicitly; consider a typed `.input` helper
+or a way to register accessors for custom/MCP tools.
+
+---
+
+## S1 — "Yes" has three faces and one verb flips
+**Severity:** low (mostly docs — the split is protocol-inherited, not fasthooks' invention)
+**Status:** open
+
+**Evidence:**
+- `allow()` → decision `"approve"`; `return None` also allows; permission requests use
+  a different family — `approve_permission()` → wire `behavior:"allow"`. So
+  `allow`↔`approve` swap meaning between the two response families.
+- The split is **inherited from the Claude Code protocol** (top-level
+  `decision: approve/block` vs PreToolUse `permissionDecision: allow/deny` vs
+  PermissionRequest `behavior: allow/deny`); `responses.py:63` already translates
+  approve→allow. So the builders already shield the author — the gap is docs.
+
+**Fix direction:** docs only — say *when* to use `return None` vs `allow()`, and that
+`allow()`/`approve_permission()` are the same intent across two protocol shapes. Do
+NOT rename builders. Tracked alongside issue #26 (observability vocabulary unification).
+
+---
+
+## Out of scope here (internal maintainability, author never touches)
+- DI resolved by `module-name == "..." and name == "..."` string match (`app.py:900+`) —
+  sturdy enough, but a module rename silently breaks injection. A registry would be safer.
+- `HookResponse` is one dataclass with per-event `to_json` branching — mild god-object,
+  hidden well by the builder functions.

--- a/SMELL.md
+++ b/SMELL.md
@@ -12,7 +12,7 @@ fix direction. Status: `open` → `in-progress` → `done` (link the commit/PR).
 
 ## S3 — Fail-open is invisible, unconfigurable for plain handlers, and `fail_mode="closed"` is a broken promise
 **Severity:** high (this is a *guardrail* library; a crashed security hook silently allowing the tool is the scariest possible default)
-**Status:** in-progress
+**Status:** done — branch `devx/smell-tracking`
 
 **Evidence:**
 - A raising handler (incl. a DI miss → `TypeError`) is caught, logged to stderr,
@@ -39,6 +39,22 @@ fix direction. Status: `open` → `in-progress` → `done` (link the commit/PR).
 3. Propagate a strategy's `Meta.fail_mode` to its handlers when included, so
    `CleanStateStrategy` actually blocks on error.
 4. Test **behavior**, not declaration: exception → deny when closed, → allow when open.
+
+**Resolution (done):**
+- `HookApp(fail_mode="open"|"closed")` default + per-decorator override
+  (`@app.pre_tool(..., fail_mode="closed")`) on every block-capable decorator
+  (`pre_tool`, `post_tool`, `on_permission`, `on`, `on_stop`, `on_subagent_stop`).
+- Enforced in `_run_handlers` except-block: synthesizes the **event-appropriate**
+  blocking response — `deny()` (PreToolUse), `deny_permission()` (PermissionRequest),
+  `block()` (Stop/SubagentStop/PostToolUse); non-blocking events stay open.
+- Strategy `Meta.fail_mode` tagged onto the handler wrapper (`base.py`), so
+  `CleanStateStrategy`'s "closed" now actually blocks. Strategy mode is
+  authoritative over the app default for its own handlers.
+- 11 behavior tests in `tests/test_fail_mode.py` (incl. DI-miss → deny, and
+  non-blocking-event → stays open).
+- **Known limitation:** per-handler mode is stashed as a function attribute, so
+  registering the *same function object* under two `fail_mode`s lets the last win.
+  Rare; documented. Lifting it would mean carrying mode in the `HandlerEntry` tuple.
 
 ---
 

--- a/src/fasthooks/__init__.py
+++ b/src/fasthooks/__init__.py
@@ -4,6 +4,8 @@ __version__ = "0.1.4"
 
 from fasthooks.app import HookApp
 from fasthooks.blueprint import Blueprint
+from fasthooks.events.base import GenericEvent, HookEventName
+from fasthooks.events.tools import ToolEvent
 from fasthooks.responses import (
     BaseHookResponse,
     ContextResponse,
@@ -22,9 +24,12 @@ __all__ = [
     "BaseHookResponse",
     "Blueprint",
     "ContextResponse",
+    "GenericEvent",
     "HookApp",
+    "HookEventName",
     "HookResponse",
     "PermissionHookResponse",
+    "ToolEvent",
     "allow",
     "approve_permission",
     "block",

--- a/src/fasthooks/app.py
+++ b/src/fasthooks/app.py
@@ -113,6 +113,10 @@ class HookApp(HandlerRegistry):
         self.log_dir = log_dir
         self.log_level = log_level
         self.fail_mode: FailMode = fail_mode
+        # Per-app typed-event overrides for custom/MCP tools, checked before the
+        # built-in TOOL_EVENT_MAP. Per-instance (not a global mutation) so apps
+        # and tests don't leak registrations into each other.
+        self._tool_event_overrides: dict[str, type[ToolEvent]] = {}
 
         # Deprecation warning for log_dir
         if log_dir is not None:
@@ -678,9 +682,48 @@ class HookApp(HandlerRegistry):
         # no block semantics -> fail open even when closed.
         return None
 
+    def register_tool_event(
+        self, tool_name: str, event_class: type[ToolEvent]
+    ) -> None:
+        """Register a typed event class for a custom or MCP tool.
+
+        Built-in tools (Bash, Write, ...) ship typed accessors; any other tool
+        falls back to the bare :class:`ToolEvent`, where you read fields via
+        ``event.tool_input``. Register a :class:`ToolEvent` subclass to get the
+        same typed-accessor / autocomplete experience for your own tool. One
+        registration covers PreToolUse, PostToolUse, and PermissionRequest.
+
+        The subclass should expose fields via ``@property`` over
+        ``self.tool_input`` and must NOT add required pydantic fields: parsing
+        happens before the handler runs, so a validation error on a missing
+        field would fail open (allow) even under ``fail_mode="closed"``.
+
+        Args:
+            tool_name: The tool's ``tool_name`` (e.g. "mcp__server__search").
+            event_class: A ToolEvent subclass.
+
+        Example:
+            class Search(ToolEvent):
+                @property
+                def query(self) -> str:
+                    return self.tool_input.get("query", "")
+
+            app.register_tool_event("mcp__server__search", Search)
+        """
+        if not (isinstance(event_class, type) and issubclass(event_class, ToolEvent)):
+            raise TypeError(
+                f"event_class must be a ToolEvent subclass, got {event_class!r}"
+            )
+        self._tool_event_overrides[tool_name] = event_class
+
     def _parse_tool_event(self, tool_name: str, data: dict[str, Any]) -> ToolEvent:
-        """Parse data into typed tool event."""
-        event_class = TOOL_EVENT_MAP.get(tool_name, ToolEvent)
+        """Parse data into typed tool event.
+
+        Resolution order: per-app override → built-in map → bare ToolEvent.
+        """
+        event_class = self._tool_event_overrides.get(tool_name) or TOOL_EVENT_MAP.get(
+            tool_name, ToolEvent
+        )
         return event_class.model_validate(data)
 
     def _parse_lifecycle_event(self, hook_type: str, data: dict[str, Any]) -> BaseEvent:

--- a/src/fasthooks/app.py
+++ b/src/fasthooks/app.py
@@ -45,8 +45,8 @@ from fasthooks.events.tools import (
 )
 from fasthooks.logging import EventLogger
 from fasthooks.observability.events import HookObservabilityEvent
-from fasthooks.registry import HandlerEntry, HandlerRegistry
-from fasthooks.responses import BaseHookResponse
+from fasthooks.registry import FAIL_MODE_ATTR, FailMode, HandlerEntry, HandlerRegistry
+from fasthooks.responses import BaseHookResponse, block, deny, deny_permission
 
 # Valid event types for @app.on_observe filter
 VALID_OBSERVER_EVENT_TYPES = frozenset(
@@ -93,6 +93,7 @@ class HookApp(HandlerRegistry):
         log_dir: str | None = None,
         log_level: str = "INFO",
         task_backend: BaseBackend | None = None,
+        fail_mode: FailMode = "open",
     ):
         """Initialize HookApp.
 
@@ -101,11 +102,17 @@ class HookApp(HandlerRegistry):
             log_dir: Directory for JSONL event logs (enables built-in logging)
             log_level: Logging verbosity
             task_backend: Backend for background tasks (default: InMemoryBackend)
+            fail_mode: Default behavior when a handler raises. "open" (default)
+                logs the error and lets the action proceed; "closed" denies the
+                action for events that can block (PreToolUse, PostToolUse,
+                PermissionRequest, Stop, SubagentStop). Override per handler via
+                the decorator's ``fail_mode=`` argument.
         """
         super().__init__()
         self.state_dir = state_dir
         self.log_dir = log_dir
         self.log_level = log_level
+        self.fail_mode: FailMode = fail_mode
 
         # Deprecation warning for log_dir
         if log_dir is not None:
@@ -643,6 +650,30 @@ class HookApp(HandlerRegistry):
 
         return response
 
+    def _fail_closed_response(
+        self, hook_event_name: str, handler_name: str, error: Exception
+    ) -> BaseHookResponse | None:
+        """Synthesize an event-appropriate blocking response for a crashed handler.
+
+        Used when the effective fail mode is "closed". Each event has its own
+        block shape, so we reuse the response builders (a bare ``deny()`` would
+        serialize wrong for a PermissionRequest). Events with no block semantics
+        return ``None`` — there's nothing to block, so they stay fail-open.
+        """
+        reason = (
+            f"Hook '{handler_name}' errored and fail_mode is closed "
+            f"({type(error).__name__}: {error})"
+        )
+        if hook_event_name == "PreToolUse":
+            return deny(reason)
+        if hook_event_name == "PermissionRequest":
+            return deny_permission(reason)
+        if hook_event_name in ("Stop", "SubagentStop", "PostToolUse"):
+            return block(reason)
+        # SessionStart/End, Notification, PreCompact, UserPromptSubmit, unknown:
+        # no block semantics -> fail open even when closed.
+        return None
+
     def _parse_tool_event(self, tool_name: str, data: dict[str, Any]) -> ToolEvent:
         """Parse data into typed tool event."""
         event_class = TOOL_EVENT_MAP.get(tool_name, ToolEvent)
@@ -863,6 +894,20 @@ class HookApp(HandlerRegistry):
                     error_type=type(e).__name__,
                     error_message=str(e),
                 )
+                # Fail open (allow) or closed (block) depending on the
+                # effective mode: per-handler override (stashed by the decorator
+                # / strategy wrapper) falls back to the app default.
+                effective_mode = getattr(handler, FAIL_MODE_ATTR, None) or self.fail_mode
+                if effective_mode == "closed":
+                    closed = self._fail_closed_response(hook_event_name, handler_name, e)
+                    if closed is not None:
+                        print(
+                            f"[fasthooks] Handler {handler_name} failed; "
+                            f"failing closed: {e}",
+                            file=sys.stderr,
+                        )
+                        return closed
+
                 # Log and continue (fail open)
                 print(f"[fasthooks] Handler {handler_name} failed: {e}", file=sys.stderr)
                 continue

--- a/src/fasthooks/app.py
+++ b/src/fasthooks/app.py
@@ -21,7 +21,7 @@ import anyio
 from fasthooks._internal.io import read_stdin, serialize_response, write_stdout
 from fasthooks.blueprint import Blueprint
 from fasthooks.depends.state import NullState, State
-from fasthooks.events.base import BaseEvent, GenericEvent
+from fasthooks.events.base import BaseEvent, GenericEvent, HookEventName
 from fasthooks.events.lifecycle import (
     Notification,
     PreCompact,
@@ -588,9 +588,9 @@ class HookApp(HandlerRegistry):
             # Tool events
             # Tool events carry a tool_name and support matcher + "*" handlers.
             tool_dicts = {
-                "PreToolUse": self._pre_tool_handlers,
-                "PostToolUse": self._post_tool_handlers,
-                "PermissionRequest": self._permission_handlers,
+                HookEventName.PRE_TOOL_USE: self._pre_tool_handlers,
+                HookEventName.POST_TOOL_USE: self._post_tool_handlers,
+                HookEventName.PERMISSION_REQUEST: self._permission_handlers,
             }
 
             if hook_type in tool_dicts:
@@ -664,11 +664,15 @@ class HookApp(HandlerRegistry):
             f"Hook '{handler_name}' errored and fail_mode is closed "
             f"({type(error).__name__}: {error})"
         )
-        if hook_event_name == "PreToolUse":
+        if hook_event_name == HookEventName.PRE_TOOL_USE:
             return deny(reason)
-        if hook_event_name == "PermissionRequest":
+        if hook_event_name == HookEventName.PERMISSION_REQUEST:
             return deny_permission(reason)
-        if hook_event_name in ("Stop", "SubagentStop", "PostToolUse"):
+        if hook_event_name in (
+            HookEventName.STOP,
+            HookEventName.SUBAGENT_STOP,
+            HookEventName.POST_TOOL_USE,
+        ):
             return block(reason)
         # SessionStart/End, Notification, PreCompact, UserPromptSubmit, unknown:
         # no block semantics -> fail open even when closed.
@@ -682,13 +686,13 @@ class HookApp(HandlerRegistry):
     def _parse_lifecycle_event(self, hook_type: str, data: dict[str, Any]) -> BaseEvent:
         """Parse data into typed lifecycle event."""
         event_classes: dict[str, type[BaseEvent]] = {
-            "Stop": Stop,
-            "SubagentStop": SubagentStop,
-            "SessionStart": SessionStart,
-            "SessionEnd": SessionEnd,
-            "PreCompact": PreCompact,
-            "UserPromptSubmit": UserPromptSubmit,
-            "Notification": Notification,
+            HookEventName.STOP: Stop,
+            HookEventName.SUBAGENT_STOP: SubagentStop,
+            HookEventName.SESSION_START: SessionStart,
+            HookEventName.SESSION_END: SessionEnd,
+            HookEventName.PRE_COMPACT: PreCompact,
+            HookEventName.USER_PROMPT_SUBMIT: UserPromptSubmit,
+            HookEventName.NOTIFICATION: Notification,
         }
         # Unknown events fall back to GenericEvent (preserves all fields) so any
         # current or future Claude Code hook is dispatchable without a release.
@@ -789,33 +793,51 @@ class HookApp(HandlerRegistry):
 
         for i, (handler, guard) in enumerate(handlers):
             handler_name = handler.__name__
-            # Bind before the guard runs: a guard that raises (common with
-            # field-based guards on unfamiliar GenericEvent payloads) must be
-            # caught below and fail open, not blow up on an unbound timer.
             handler_start = time.perf_counter()
 
-            try:
-                # Check guard condition (supports async guards)
-                if guard is not None:
+            # A `when=` guard is a filter, not the safety check. If it can't be
+            # evaluated (e.g. a field-based guard raising on an unfamiliar
+            # GenericEvent payload), the handler simply doesn't match. Guard
+            # errors ALWAYS fail open (skip the handler), independent of
+            # fail_mode — only the handler body below honors fail_mode.
+            if guard is not None:
+                try:
                     if inspect.iscoroutinefunction(guard):
                         guard_result = await guard(event)
                     else:
                         guard_result = await anyio.to_thread.run_sync(
                             functools.partial(guard, event)
                         )
-                    if not guard_result:
-                        # Emit handler_skip for guard failure
-                        self._emit(
-                            event_type="handler_skip",
-                            hook_id=hook_id,
-                            session_id=session_id,
-                            hook_event_name=hook_event_name,
-                            tool_name=tool_name,
-                            handler_name=handler_name,
-                            skip_reason="guard failed",
-                        )
-                        continue
+                except Exception as e:
+                    self._emit(
+                        event_type="handler_skip",
+                        hook_id=hook_id,
+                        session_id=session_id,
+                        hook_event_name=hook_event_name,
+                        tool_name=tool_name,
+                        handler_name=handler_name,
+                        skip_reason=f"guard error: {type(e).__name__}",
+                    )
+                    print(
+                        f"[fasthooks] Guard for {handler_name} errored "
+                        f"(skipping handler): {e}",
+                        file=sys.stderr,
+                    )
+                    continue
+                if not guard_result:
+                    # Emit handler_skip for guard failure
+                    self._emit(
+                        event_type="handler_skip",
+                        hook_id=hook_id,
+                        session_id=session_id,
+                        hook_event_name=hook_event_name,
+                        tool_name=tool_name,
+                        handler_name=handler_name,
+                        skip_reason="guard failed",
+                    )
+                    continue
 
+            try:
                 # Emit handler_start
                 self._emit(
                     event_type="handler_start",

--- a/src/fasthooks/events/__init__.py
+++ b/src/fasthooks/events/__init__.py
@@ -1,5 +1,5 @@
 """Event models for Claude Code hooks."""
-from fasthooks.events.base import BaseEvent, GenericEvent
+from fasthooks.events.base import BaseEvent, GenericEvent, HookEventName
 from fasthooks.events.lifecycle import (
     Notification,
     PermissionRequest,
@@ -27,6 +27,7 @@ __all__ = [
     # Base
     "BaseEvent",
     "GenericEvent",
+    "HookEventName",
     # Tools
     "Bash",
     "Edit",

--- a/src/fasthooks/events/base.py
+++ b/src/fasthooks/events/base.py
@@ -1,9 +1,36 @@
 """Base event model for all hook events."""
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
+
+
+class HookEventName(str, Enum):
+    """Canonical Claude Code ``hook_event_name`` values.
+
+    Subclasses ``str`` (like :class:`fasthooks.tasks.base.TaskStatus`), so
+    members are drop-in interchangeable with the raw strings Claude Code sends
+    — usable as dict keys, in ``==`` comparisons, and JSON-serialized to their
+    wire value without conversion. Centralizes the magic strings the dispatcher
+    keys off, instead of scattering literals like ``"PreToolUse"``.
+
+    Note: this enumerates the events fasthooks models. Unknown/new events still
+    dispatch via :class:`GenericEvent` — the enum is for the known set, not a
+    closed-world constraint.
+    """
+
+    PRE_TOOL_USE = "PreToolUse"
+    POST_TOOL_USE = "PostToolUse"
+    PERMISSION_REQUEST = "PermissionRequest"
+    STOP = "Stop"
+    SUBAGENT_STOP = "SubagentStop"
+    SESSION_START = "SessionStart"
+    SESSION_END = "SessionEnd"
+    PRE_COMPACT = "PreCompact"
+    USER_PROMPT_SUBMIT = "UserPromptSubmit"
+    NOTIFICATION = "Notification"
 
 
 class BaseEvent(BaseModel):

--- a/src/fasthooks/registry.py
+++ b/src/fasthooks/registry.py
@@ -3,10 +3,23 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 # Type alias for handler with optional guard
 HandlerEntry = tuple[Callable[..., Any], Callable[..., Any] | None]
+
+# Per-handler fail-mode is stashed on the function so it survives into dispatch
+# without changing the HandlerEntry tuple shape (which ripples through Blueprint,
+# strategy wrapping, and the test clients). Read by HookApp._run_handlers.
+FAIL_MODE_ATTR = "_fasthooks_fail_mode"
+
+FailMode = Literal["open", "closed"]
+
+
+def _tag_fail_mode(func: Callable[..., Any], fail_mode: FailMode | None) -> None:
+    """Stash a per-handler fail-mode override on the function, if given."""
+    if fail_mode is not None:
+        setattr(func, FAIL_MODE_ATTR, fail_mode)
 
 
 class HandlerRegistry:
@@ -27,7 +40,10 @@ class HandlerRegistry:
     # ═══════════════════════════════════════════════════════════════
 
     def pre_tool(
-        self, *tools: str, when: Callable[..., Any] | None = None
+        self,
+        *tools: str,
+        when: Callable[..., Any] | None = None,
+        fail_mode: FailMode | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator to register a PreToolUse handler.
 
@@ -35,12 +51,16 @@ class HandlerRegistry:
             *tools: Tool names to match (e.g., "Bash", "Write").
                     If empty, registers as catch-all handler for ALL tools.
             when: Optional guard function that receives event, returns bool
+            fail_mode: Override the app's fail mode for this handler. "closed"
+                    means a crash in this handler denies the tool instead of
+                    silently allowing it. Defaults to the app's setting.
 
         Returns:
             Decorator function
         """
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            _tag_fail_mode(func, fail_mode)
             targets = tools if tools else ("*",)
             for tool in targets:
                 self._pre_tool_handlers[tool].append((func, when))
@@ -49,7 +69,10 @@ class HandlerRegistry:
         return decorator
 
     def post_tool(
-        self, *tools: str, when: Callable[..., Any] | None = None
+        self,
+        *tools: str,
+        when: Callable[..., Any] | None = None,
+        fail_mode: FailMode | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator to register a PostToolUse handler.
 
@@ -57,12 +80,15 @@ class HandlerRegistry:
             *tools: Tool names to match.
                     If empty, registers as catch-all handler for ALL tools.
             when: Optional guard function
+            fail_mode: Override the app's fail mode for this handler (see
+                    :meth:`pre_tool`).
 
         Returns:
             Decorator function
         """
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            _tag_fail_mode(func, fail_mode)
             targets = tools if tools else ("*",)
             for tool in targets:
                 self._post_tool_handlers[tool].append((func, when))
@@ -75,7 +101,10 @@ class HandlerRegistry:
     # ═══════════════════════════════════════════════════════════════
 
     def on(
-        self, event_name: str, when: Callable[..., Any] | None = None
+        self,
+        event_name: str,
+        when: Callable[..., Any] | None = None,
+        fail_mode: FailMode | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Register a handler for any hook event by name.
 
@@ -88,6 +117,10 @@ class HandlerRegistry:
         Args:
             event_name: The ``hook_event_name`` to match (e.g. "FileChanged").
             when: Optional guard function that receives the event, returns bool.
+            fail_mode: Override the app's fail mode for this handler (see
+                    :meth:`pre_tool`). Only events with block semantics
+                    (PreToolUse, PostToolUse, PermissionRequest, Stop,
+                    SubagentStop) can fail closed; others always fail open.
 
         Example:
             @app.on("FileChanged")
@@ -96,6 +129,7 @@ class HandlerRegistry:
         """
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            _tag_fail_mode(func, fail_mode)
             self._lifecycle_handlers[event_name].append((func, when))
             return func
 
@@ -106,22 +140,32 @@ class HandlerRegistry:
     # ═══════════════════════════════════════════════════════════════
 
     def on_stop(
-        self, when: Callable[..., Any] | None = None
+        self,
+        when: Callable[..., Any] | None = None,
+        fail_mode: FailMode | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        """Decorator for Stop events (main agent finished)."""
+        """Decorator for Stop events (main agent finished).
+
+        ``fail_mode="closed"`` blocks the stop (forces Claude to continue) if
+        this handler crashes, instead of silently letting the session end.
+        """
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            _tag_fail_mode(func, fail_mode)
             self._lifecycle_handlers["Stop"].append((func, when))
             return func
 
         return decorator
 
     def on_subagent_stop(
-        self, when: Callable[..., Any] | None = None
+        self,
+        when: Callable[..., Any] | None = None,
+        fail_mode: FailMode | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator for SubagentStop events."""
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            _tag_fail_mode(func, fail_mode)
             self._lifecycle_handlers["SubagentStop"].append((func, when))
             return func
 
@@ -183,7 +227,10 @@ class HandlerRegistry:
         return decorator
 
     def on_permission(
-        self, *tools: str, when: Callable[..., Any] | None = None
+        self,
+        *tools: str,
+        when: Callable[..., Any] | None = None,
+        fail_mode: FailMode | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator for PermissionRequest events.
 
@@ -191,12 +238,15 @@ class HandlerRegistry:
             *tools: Tool names to match (e.g., "Bash", "Write").
                     If empty, registers as catch-all handler for ALL tools.
             when: Optional guard function
+            fail_mode: Override the app's fail mode for this handler. "closed"
+                    denies the permission if this handler crashes.
 
         Returns:
             Decorator function
         """
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            _tag_fail_mode(func, fail_mode)
             targets = tools if tools else ("*",)
             for tool in targets:
                 self._permission_handlers[tool].append((func, when))

--- a/src/fasthooks/strategies/base.py
+++ b/src/fasthooks/strategies/base.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from fasthooks import Blueprint
+from fasthooks.registry import FAIL_MODE_ATTR
 
 from ..observability import DecisionEvent, ErrorEvent, ObservabilityEvent
 
@@ -265,6 +266,10 @@ class Strategy(ABC):
                     )
                 )
 
+        # Tag the wrapper with the strategy's fail mode so dispatch enforces it
+        # (e.g. CleanStateStrategy's "closed" actually blocks on error). A
+        # strategy's declared fail_mode is authoritative for its own handlers.
+        setattr(wrapped, FAIL_MODE_ATTR, getattr(self.Meta, "fail_mode", "open"))
         return wrapped
 
     def get_meta(self) -> StrategyMeta:

--- a/tests/test_fail_mode.py
+++ b/tests/test_fail_mode.py
@@ -1,0 +1,159 @@
+"""Fail-mode behavior: what happens to the action when a handler *crashes*.
+
+These test BEHAVIOR (the synthesized response), not declaration. The prior gap
+was that fail_mode="closed" was declared on strategies but never enforced — a
+crashed guard always failed open. For a guardrail library that's the scariest
+default, so it's a first-class test target.
+"""
+from __future__ import annotations
+
+from fasthooks import HookApp
+from fasthooks.blueprint import Blueprint
+from fasthooks.strategies.base import Strategy
+from fasthooks.testing import MockEvent, TestClient
+
+
+def _raiser():
+    """Return a *fresh* crashing handler.
+
+    Each test uses its own function object: fail_mode is stashed as a function
+    attribute, so reusing one shared function across registrations would let one
+    test's tag leak into another (and mirrors a real gotcha — registering the
+    same function with two fail_modes, last one wins).
+    """
+
+    def boom(event):
+        raise RuntimeError("kaboom")
+
+    return boom
+
+
+# ── app-level default ────────────────────────────────────────────────────────
+
+def test_open_is_default_crash_allows():
+    """Default fail_mode is open: a crashed pre_tool handler lets the tool run."""
+    app = HookApp()
+    app.pre_tool("Bash")(_raiser())
+    assert TestClient(app).send(MockEvent.bash(command="ls")) is None
+
+
+def test_app_closed_crash_denies_pre_tool():
+    """fail_mode='closed' turns a crashed PreToolUse handler into a deny."""
+    app = HookApp(fail_mode="closed")
+    app.pre_tool("Bash")(_raiser())
+    response = TestClient(app).send(MockEvent.bash(command="ls"))
+    assert response is not None
+    assert response.decision == "deny"
+
+
+# ── per-handler override (both directions) ───────────────────────────────────
+
+def test_per_handler_closed_overrides_app_open():
+    app = HookApp()  # open
+    app.pre_tool("Bash", fail_mode="closed")(_raiser())
+    response = TestClient(app).send(MockEvent.bash(command="ls"))
+    assert response is not None and response.decision == "deny"
+
+
+def test_per_handler_open_overrides_app_closed():
+    app = HookApp(fail_mode="closed")
+    app.pre_tool("Bash", fail_mode="open")(_raiser())
+    assert TestClient(app).send(MockEvent.bash(command="ls")) is None
+
+
+# ── event-appropriate blocking response ──────────────────────────────────────
+
+def test_closed_stop_blocks():
+    """Stop has no deny; closed must emit block (force-continue), not deny."""
+    app = HookApp(fail_mode="closed")
+    app.on_stop()(_raiser())
+    response = TestClient(app).send(MockEvent.stop())
+    assert response is not None and response.decision == "block"
+
+
+def test_closed_permission_denies_with_permission_shape():
+    """PermissionRequest must use the permission response, not a bare deny()."""
+    app = HookApp(fail_mode="closed")
+    app.on_permission("Bash")(_raiser())
+    response = TestClient(app).send(MockEvent.permission_bash(command="ls"))
+    assert response is not None
+    # PermissionHookResponse carries behavior, not decision
+    assert getattr(response, "behavior", None) == "deny"
+
+
+def test_closed_non_blocking_event_stays_open():
+    """SessionStart has no block semantics: closed still fails open, no crash."""
+    app = HookApp(fail_mode="closed")
+    app.on_session_start()(_raiser())
+    assert TestClient(app).send(MockEvent.session_start()) is None
+
+
+# ── DI miss (a crash via wiring, not handler body) ───────────────────────────
+
+def test_closed_di_miss_denies():
+    """Annotating a non-injectable param raises TypeError at call; closed denies."""
+
+    class NotInjectable: ...
+
+    def handler(event, dep: NotInjectable):  # dep can't be resolved -> TypeError
+        return None
+
+    app = HookApp(fail_mode="closed")
+    app.pre_tool("Bash")(handler)
+    response = TestClient(app).send(MockEvent.bash(command="ls"))
+    assert response is not None and response.decision == "deny"
+
+
+# ── no regression on the happy path ──────────────────────────────────────────
+
+def test_closed_does_not_affect_successful_handler():
+    """A handler that doesn't crash is untouched by fail_mode."""
+    app = HookApp(fail_mode="closed")
+
+    @app.pre_tool("Bash")
+    def ok(event):
+        return None  # allow
+
+    assert TestClient(app).send(MockEvent.bash(command="ls")) is None
+
+
+# ── strategy propagation (the broken promise) ────────────────────────────────
+
+class _ClosedStrategy(Strategy):
+    class Meta:
+        name = "closed-strat"
+        version = "1.0.0"
+        hooks = ["on_stop"]
+        fail_mode = "closed"
+
+    def _build_blueprint(self) -> Blueprint:
+        bp = Blueprint("closed")
+        bp.on_stop()(_raiser())
+        return bp
+
+
+class _OpenStrategy(Strategy):
+    class Meta:
+        name = "open-strat"
+        version = "1.0.0"
+        hooks = ["on_stop"]  # fail_mode defaults to "open"
+
+    def _build_blueprint(self) -> Blueprint:
+        bp = Blueprint("open")
+        bp.on_stop()(_raiser())
+        return bp
+
+
+def test_closed_strategy_blocks_on_error():
+    """CleanState-style 'closed' strategy now actually blocks when it crashes."""
+    app = HookApp()  # app default open
+    app.include_strategy(_ClosedStrategy())
+    response = TestClient(app).send(MockEvent.stop())
+    assert response is not None and response.decision == "block"
+
+
+def test_strategy_fail_mode_is_authoritative_over_app():
+    """A strategy's own (default open) mode wins over a closed app default."""
+    app = HookApp(fail_mode="closed")
+    app.include_strategy(_OpenStrategy())
+    assert TestClient(app).send(MockEvent.stop()) is None

--- a/tests/test_fail_mode.py
+++ b/tests/test_fail_mode.py
@@ -104,6 +104,35 @@ def test_closed_di_miss_denies():
     assert response is not None and response.decision == "deny"
 
 
+# ── guards fail open even in closed mode (a guard is a filter) ───────────────
+
+def test_closed_guard_raise_skips_not_blocks():
+    """A `when=` guard that raises must skip the handler, NOT trip fail-closed.
+
+    A guard is a filter: if it can't evaluate (e.g. field missing on the
+    payload) the handler doesn't match. Blocking the tool because a filter
+    threw would be wrong — only the handler *body* honors fail_mode.
+    """
+    app = HookApp(fail_mode="closed")
+
+    @app.pre_tool("Bash", when=lambda e: e.does_not_exist, fail_mode="closed")
+    def guarded(event):
+        return None
+
+    assert TestClient(app).send(MockEvent.bash(command="ls")) is None
+
+
+def test_closed_guard_false_skips():
+    """A guard returning False skips cleanly (sanity alongside the raise case)."""
+    app = HookApp(fail_mode="closed")
+
+    @app.pre_tool("Bash", when=lambda e: False)
+    def guarded(event):
+        return _raiser()  # never reached
+
+    assert TestClient(app).send(MockEvent.bash(command="ls")) is None
+
+
 # ── no regression on the happy path ──────────────────────────────────────────
 
 def test_closed_does_not_affect_successful_handler():

--- a/tests/test_tool_event_registration.py
+++ b/tests/test_tool_event_registration.py
@@ -1,0 +1,107 @@
+"""Typed events for custom / MCP tools via register_tool_event.
+
+Built-in tools ship typed accessors; everything else falls back to bare
+ToolEvent (read via event.tool_input). Registration extends the typed-accessor
+experience to custom tools — opt-in, per-app, covering pre/post/permission.
+"""
+from __future__ import annotations
+
+import pytest
+
+from fasthooks import HookApp, ToolEvent
+from fasthooks.testing import TestClient
+
+
+class Search(ToolEvent):
+    """A custom MCP tool event with a typed accessor over tool_input."""
+
+    @property
+    def query(self) -> str:
+        return self.tool_input.get("query", "")
+
+
+def _raw(hook_event_name: str = "PreToolUse", tool: str = "mcp__srv__search"):
+    return {
+        "hook_event_name": hook_event_name,
+        "session_id": "s",
+        "cwd": "/",
+        "tool_name": tool,
+        "tool_input": {"query": "hello"},
+        "tool_use_id": "t1",
+    }
+
+
+def test_registered_tool_gets_typed_event():
+    app = HookApp()
+    app.register_tool_event("mcp__srv__search", Search)
+    seen = {}
+
+    @app.pre_tool("mcp__srv__search")
+    def handler(event):
+        seen["type"] = type(event)
+        seen["query"] = event.query  # typed accessor
+
+    TestClient(app).send_raw(_raw())
+    assert seen["type"] is Search
+    assert seen["query"] == "hello"
+
+
+def test_one_registration_covers_post_tool():
+    """A single registration applies to PostToolUse too (not just pre)."""
+    app = HookApp()
+    app.register_tool_event("mcp__srv__search", Search)
+    seen = {}
+
+    @app.post_tool("mcp__srv__search")
+    def handler(event):
+        seen["type"] = type(event)
+
+    TestClient(app).send_raw(_raw(hook_event_name="PostToolUse"))
+    assert seen["type"] is Search
+
+
+def test_unregistered_tool_falls_back_to_bare_tool_event():
+    """Unknown tools parse as ToolEvent; tool_input works, accessors don't exist."""
+    app = HookApp()
+    captured = {}
+
+    @app.pre_tool("mcp__srv__search")
+    def handler(event):
+        captured["event"] = event
+
+    TestClient(app).send_raw(_raw())
+    event = captured["event"]
+    assert type(event) is ToolEvent
+    # The raw payload is always reachable...
+    assert event.tool_input["query"] == "hello"
+    # ...but there's no typed accessor — it raises, it does not silently return None.
+    with pytest.raises(AttributeError):
+        _ = event.query
+
+
+def test_register_rejects_non_tool_event():
+    app = HookApp()
+    with pytest.raises(TypeError):
+        app.register_tool_event("X", dict)  # type: ignore[arg-type]
+
+    class NotAToolEvent:
+        pass
+
+    with pytest.raises(TypeError):
+        app.register_tool_event("X", NotAToolEvent)  # type: ignore[arg-type]
+
+
+def test_registration_is_per_app():
+    """Registering on one app must not leak into another (no global mutation)."""
+    registered = HookApp()
+    registered.register_tool_event("mcp__srv__search", Search)
+
+    plain = HookApp()
+    captured = {}
+
+    @plain.pre_tool("mcp__srv__search")
+    def handler(event):
+        captured["type"] = type(event)
+
+    TestClient(plain).send_raw(_raw())
+    assert captured["type"] is ToolEvent  # unaffected by the other app


### PR DESCRIPTION
## Summary

A focused **authoring-ergonomics** pass on the hook surface (companion to the strategic `REVIEW-devx.md`). Adds `SMELL.md` as a living tracker and resolves its three seeded items. Two of the three uncovered real bugs, not just rough edges.

## SMELL.md
New tracker for authoring friction — "how easy is it to write a *correct* hook, and what bites you on the unhappy path." Each item: severity, evidence (`file:line`), fix direction, resolution.

## S3 — fail mode (high severity; a guardrail-library safety hole)
`fail_mode="closed"` was declared on `StrategyMeta` and set by `CleanStateStrategy` ("safety first") but **never consumed in dispatch** — a crashed guard always failed open. For a guardrail library, a crashed security hook silently allowing the tool is the scariest possible default.

- `HookApp(fail_mode="open"|"closed")` default + per-decorator override on every block-capable decorator (`pre_tool`/`post_tool`/`on_permission`/`on`/`on_stop`/`on_subagent_stop`). Per-handler mode stashed as a function attribute (keeps the `HandlerEntry` tuple shape — no ripple through Blueprint/strategy/test clients).
- Enforced in `_run_handlers`: a crashed handler in closed mode returns the **event-appropriate** blocking response — `deny()` (PreToolUse), `deny_permission()` (PermissionRequest), `block()` (Stop/SubagentStop/PostToolUse). Events with no block semantics stay open, logged.
- Strategy `Meta.fail_mode` tagged onto the handler wrapper, so `CleanStateStrategy` now actually blocks on error. Strategy mode is authoritative over the app default for its own handlers.
- **Bug found in review:** a `when=` guard that *raised* was tripping fail-closed. A guard is a filter, not the safety check — guard evaluation now sits in its own fail-open `try`; only the handler *body* honors `fail_mode`.
- Replaced scattered `"PreToolUse"` literals in dispatch with `HookEventName(str, Enum)` (mirrors the existing `TaskStatus(str, Enum)`; str-subclass keeps it drop-in with raw wire strings).
- 13 behavior tests (incl. DI-miss -> deny, non-blocking event stays open, guard-raise -> skip).

## S2 — typed events for custom / MCP tools (medium)
Built-in tools ship typed accessors; any other tool fell back to bare `ToolEvent` with no signal. The gap was discoverability + autocomplete, **not** silent wrong values (a non-modeled `event.query` raises `AttributeError`).

- **Docs first:** README "Custom & MCP tools" leads with "`event.tool_input` always works for any tool," then the opt-in.
- `app.register_tool_event(name, ToolEventSubclass)`: per-app (no global mutation), validates the subclass, one registration covers pre/post/permission.
- Exported `ToolEvent`/`HookEventName`/`GenericEvent` at top level.
- **Documented cross-feature constraint:** custom event classes must be `@property`-only / keep `extra="allow"` / no required fields — parsing runs in `_dispatch` (outside `_run_handlers`), so a required-field validation error would fail *open* even under `fail_mode="closed"`.
- 5 tests (typed pre+post, bare fallback + AttributeError, validation, per-app isolation).

## S1 — the three ways to say "yes" (low; docs)
The "yes" vocabulary has three faces (`return None`, `allow()`, `approve_permission()`) and a verb that flips (`allow`<->`approve`) — but that split is **inherited from the Claude Code protocol**, so the fix is docs, not renaming builders.

- README "Responses" rewritten: `return None` vs `allow()` (equivalent for a bare allow; reach for `allow(...)` only to attach `message`/`modify`), and `allow()` vs `approve_permission()` (same intent, two protocol shapes).

## Verification
`665 tests pass`, ruff + mypy clean. New behavior verified empirically (fail-mode matrix, guard-raise, register resolution, bare-allow == None) before each step.

## Related
- #26 — `allow`/`approve` observability-vocabulary unification (S1 context).
- Pre-existing `REVIEW-devx.md` strategic lens (this PR is the ergonomics lens).
