### PR TITLE
fix(observability): unify decision vocabulary on 'allow' (#26)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -200,7 +200,7 @@ def test_observability_events_in_order(self):
 
     # Verify decision content
     decision_event = events[1]
-    assert decision_event.decision == "approve"
+    assert decision_event.decision == "allow"  # canonical observability vocab (#26)
 ```
 
 ### Testing Custom Events

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.14.9",
+    "httpx>=0.27",  # FastAPI/Starlette TestClient for studio endpoint tests
 ]
 docs = [
     "mkdocs-material>=9.0",

--- a/src/fasthooks/app.py
+++ b/src/fasthooks/app.py
@@ -45,7 +45,11 @@ from fasthooks.events.tools import (
     Write,
 )
 from fasthooks.logging import EventLogger
-from fasthooks.observability.events import HookObservabilityEvent
+from fasthooks.observability.events import (
+    Decision,
+    HookObservabilityEvent,
+    normalize_decision,
+)
 from fasthooks.registry import FAIL_MODE_ATTR, FailMode, HandlerEntry, HandlerRegistry
 from fasthooks.responses import BaseHookResponse, block, deny, deny_permission
 
@@ -645,12 +649,10 @@ class HookApp(HandlerRegistry):
 
         # Emit hook_end
         duration_ms = (time.perf_counter() - start_time) * 1000
-        final_decision = None
-        final_reason = None
-        if response:
-            # Extract decision from response
-            final_decision = getattr(response, "decision", None)
-            final_reason = getattr(response, "reason", None)
+        # hook-level record: no final response means no decision (absent), so
+        # default=None here (unlike per-handler records which default to ALLOW).
+        final_decision = normalize_decision(response)
+        final_reason = getattr(response, "reason", None) if response else None
 
         self._emit(
             event_type="hook_end",
@@ -915,12 +917,10 @@ class HookApp(HandlerRegistry):
 
                 handler_duration = (time.perf_counter() - handler_start) * 1000
 
-                # Determine decision from response
-                decision = "allow"
-                reason = None
-                if response:
-                    decision = getattr(response, "decision", None) or "allow"
-                    reason = getattr(response, "reason", None)
+                # Determine decision from response. A handler that returned
+                # nothing allowed, so a missing decision records as ALLOW.
+                decision = normalize_decision(response, default=Decision.ALLOW)
+                reason = getattr(response, "reason", None) if response else None
 
                 # Emit handler_end
                 self._emit(

--- a/src/fasthooks/observability/__init__.py
+++ b/src/fasthooks/observability/__init__.py
@@ -19,10 +19,12 @@ if TYPE_CHECKING:
     from .base import BaseObserver
     from .enums import TerminalOutput, Verbosity
     from .events import (
+        Decision,
         DecisionEvent,
         ErrorEvent,
         HookObservabilityEvent,
         ObservabilityEvent,
+        normalize_decision,
     )
     from .observers import EventCapture, FileObserver, SQLiteObserver
 
@@ -37,6 +39,9 @@ __all__ = [
     "ObservabilityEvent",
     "DecisionEvent",
     "ErrorEvent",
+    # Decision vocabulary
+    "Decision",
+    "normalize_decision",
     # Enums
     "Verbosity",
     "TerminalOutput",
@@ -49,6 +54,8 @@ _LAZY = {
     "DecisionEvent": ".events",
     "ErrorEvent": ".events",
     "ObservabilityEvent": ".events",
+    "Decision": ".events",
+    "normalize_decision": ".events",
     "BaseObserver": ".base",
     "FileObservabilityBackend": ".backend",
     "TerminalOutput": ".enums",

--- a/src/fasthooks/observability/events.py
+++ b/src/fasthooks/observability/events.py
@@ -4,9 +4,73 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from typing import Any, Literal
+from enum import Enum
+from typing import Any, Literal, cast, overload
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# =============================================================================
+# Decision vocabulary
+# =============================================================================
+
+
+class Decision(str, Enum):
+    """The canonical decision vocabulary recorded across observability.
+
+    "allow" is the modern Claude Code term (``permissionDecision: allow/deny/ask``);
+    "approve" is the deprecated wire value that maps to "allow". We record the
+    modern term everywhere so a single query works regardless of which code path
+    produced the row. ``HookResponse.decision`` keeps "approve" internally (it
+    maps correctly at the protocol layer) — only the observability record is
+    normalized.
+    """
+
+    ALLOW = "allow"
+    DENY = "deny"
+    BLOCK = "block"
+    ASK = "ask"
+
+
+@overload
+def normalize_decision(value: object, *, default: Decision) -> Decision | str: ...
+@overload
+def normalize_decision(value: object, *, default: None = ...) -> Decision | str | None: ...
+def normalize_decision(value: object, *, default: Decision | None = None) -> Decision | str | None:
+    """Map a hook response, a raw decision string, or None to :class:`Decision`.
+
+    Accepts a response object (reads ``.behavior`` for permission responses,
+    else ``.decision``), a raw string, an existing :class:`Decision`, or None.
+    ``approve`` is folded into ``allow``. An *unrecognized* string is passed
+    through unchanged rather than masked as ``allow`` — a miswrite should be
+    visible in the data, not silently recorded as the most permissive outcome.
+
+    ``default`` is returned when there is no decision to read (None, or a
+    response like ``context()`` that carries neither). Callers choose what "no
+    decision" means: ``Decision.ALLOW`` for per-handler records (a handler that
+    returned nothing allowed), or None for hook-level records (absent).
+    """
+    if value is None:
+        return default
+    behavior = getattr(value, "behavior", None)
+    if behavior == "deny":
+        return Decision.DENY
+    if behavior == "allow":
+        return Decision.ALLOW
+    raw = getattr(value, "decision", None)
+    if raw is None and isinstance(value, str):
+        raw = value
+    if raw is None:
+        return default
+    if raw == "deny":
+        return Decision.DENY
+    if raw == "block":
+        return Decision.BLOCK
+    if raw == "ask":
+        return Decision.ASK
+    if raw in ("allow", "approve"):
+        return Decision.ALLOW
+    return cast(str, raw)  # unknown: surface it, don't mask as allow
+
 
 # =============================================================================
 # HookApp Observability Events
@@ -34,9 +98,16 @@ class HookObservabilityEvent(BaseModel):
     # Timing (for *_end events only)
     duration_ms: float | None = None  # Handler execution time (excludes DI)
 
-    # Decision (for handler_end, hook_end)
-    decision: str | None = None  # "allow", "deny", "block"
+    # Decision (for handler_end, hook_end) — canonical Decision vocabulary.
+    decision: Decision | str | None = None
     reason: str | None = None  # Denial reason if any
+
+    @field_validator("decision", mode="before")
+    @classmethod
+    def _normalize_decision(cls, v: object) -> Decision | str | None:
+        # Coerce here too, never raise: this model is constructed in HookApp._emit
+        # *outside* a try, so a ValidationError would break the hook (fail-open).
+        return normalize_decision(v)
 
     # Content (truncated)
     input_preview: str | None = None  # First 4096 chars of hook input JSON
@@ -87,10 +158,15 @@ class DecisionEvent(ObservabilityEvent):
     """Emitted when strategy returns a decision."""
 
     event_type: Literal["decision"] = "decision"
-    decision: Literal["approve", "deny", "block"]
+    decision: Decision | str  # canonical Decision; tolerant of unknown passthrough
     reason: str | None = None
     message: str | None = None  # Injected message
     dry_run: bool = False  # True if dry-run mode
+
+    @field_validator("decision", mode="before")
+    @classmethod
+    def _normalize_decision(cls, v: object) -> Decision | str | None:
+        return normalize_decision(v)
 
 
 class ErrorEvent(ObservabilityEvent):

--- a/src/fasthooks/observability/observers/sqlite.py
+++ b/src/fasthooks/observability/observers/sqlite.py
@@ -62,6 +62,16 @@ class SQLiteObserver(BaseObserver):
             conn.execute("CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type)")
 
+            # One-time migration: fold the deprecated "approve" decision into the
+            # canonical "allow". Gated on user_version so it runs once per DB, not
+            # a full-table scan on every observer connect.
+            (version,) = conn.execute("PRAGMA user_version").fetchone()
+            if version < 1:
+                conn.execute(
+                    "UPDATE events SET decision = 'allow' WHERE decision = 'approve'"
+                )
+                conn.execute("PRAGMA user_version = 1")
+
     def _write(self, event: HookObservabilityEvent) -> None:
         """Insert event into database.
 

--- a/src/fasthooks/observability/observers/sqlite.py
+++ b/src/fasthooks/observability/observers/sqlite.py
@@ -12,6 +12,32 @@ if TYPE_CHECKING:
     from fasthooks.observability.events import HookObservabilityEvent
 
 
+def migrate_decision_vocab(conn: sqlite3.Connection) -> None:
+    """Fold the deprecated ``approve`` decision into canonical ``allow``, once.
+
+    The events store can predate the allow/approve unification (#26). Both the
+    writer (``SQLiteObserver`` on init) and the read-only studio server (on open)
+    call this, so any DB they touch converges on one vocabulary — every read path
+    then sees canonical values with no per-query folding.
+
+    Gated on ``PRAGMA user_version``: a one-time UPDATE, never a full-table scan
+    on every connect, and a pure no-op on an already-migrated DB (the common
+    case). Commits itself so it works for callers that don't wrap it in a
+    committing ``with`` block (the studio server opens bare connections).
+    """
+    (version,) = conn.execute("PRAGMA user_version").fetchone()
+    if version >= 1:
+        return
+    # The DB may be brand new (e.g. studio aimed at a fresh path) with no table.
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'events'"
+    ).fetchone()
+    if table_exists:
+        conn.execute("UPDATE events SET decision = 'allow' WHERE decision = 'approve'")
+    conn.execute("PRAGMA user_version = 1")
+    conn.commit()
+
+
 class SQLiteObserver(BaseObserver):
     """Write events to SQLite for studio visualization.
 
@@ -62,15 +88,7 @@ class SQLiteObserver(BaseObserver):
             conn.execute("CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type)")
 
-            # One-time migration: fold the deprecated "approve" decision into the
-            # canonical "allow". Gated on user_version so it runs once per DB, not
-            # a full-table scan on every observer connect.
-            (version,) = conn.execute("PRAGMA user_version").fetchone()
-            if version < 1:
-                conn.execute(
-                    "UPDATE events SET decision = 'allow' WHERE decision = 'approve'"
-                )
-                conn.execute("PRAGMA user_version = 1")
+            migrate_decision_vocab(conn)
 
     def _write(self, event: HookObservabilityEvent) -> None:
         """Insert event into database.

--- a/src/fasthooks/strategies/base.py
+++ b/src/fasthooks/strategies/base.py
@@ -13,27 +13,10 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from fasthooks import Blueprint
+from fasthooks.observability.events import Decision, normalize_decision
 from fasthooks.registry import FAIL_MODE_ATTR
 
 from ..observability import DecisionEvent, ErrorEvent, ObservabilityEvent
-
-DecisionLiteral = Literal["approve", "deny", "block"]
-
-
-def _decision_of(result: object) -> DecisionLiteral:
-    """Map a hook response to its observability decision.
-
-    ``HookResponse`` exposes ``.decision`` directly. ``PermissionHookResponse``
-    uses ``.behavior`` ("allow"/"deny") instead, so a permission deny is
-    recorded as a deny rather than silently defaulting to approve. Anything
-    else (context responses, bare allows) is treated as approve.
-    """
-    decision = getattr(result, "decision", None)
-    if decision == "deny" or getattr(result, "behavior", None) == "deny":
-        return "deny"
-    if decision == "block":
-        return "block"
-    return "approve"
 
 
 class StrategyMeta(BaseModel):
@@ -231,7 +214,8 @@ class Strategy(ABC):
 
                 # Emit decision if result returned
                 if result is not None:
-                    decision = _decision_of(result)
+                    # result is not None here, so a missing decision = ALLOW.
+                    decision = normalize_decision(result, default=Decision.ALLOW)
                     self._emit(
                         DecisionEvent(
                             session_id=self._current_session_id,

--- a/src/fasthooks/studio/server.py
+++ b/src/fasthooks/studio/server.py
@@ -365,12 +365,18 @@ def create_app(db_path: Path) -> FastAPI:
 
         # Decision breakdown
         decisions = conn.execute("""
-            SELECT decision, COUNT(*) as count
+            SELECT
+                CASE WHEN decision = 'approve' THEN 'allow' ELSE decision END
+                    AS decision,
+                COUNT(*) as count
             FROM events
             WHERE event_type = 'handler_end' AND decision IS NOT NULL
-            GROUP BY decision
+            GROUP BY 1
         """).fetchall()
 
+        # The CASE folds the deprecated "approve" into "allow" so the breakdown is
+        # coherent even on a studio.db whose rows predate the migration (the
+        # read-only server never runs the observer's one-time migration).
         decision_counts = {row["decision"]: row["count"] for row in decisions}
 
         # Average handler duration

--- a/src/fasthooks/studio/server.py
+++ b/src/fasthooks/studio/server.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from fasthooks.observability.observers.sqlite import migrate_decision_vocab
 from fasthooks.studio.connection_manager import ConnectionManager
 from fasthooks.transcript import Transcript
 
@@ -67,6 +68,12 @@ class ConversationStats(TypedDict):
 
 def create_app(db_path: Path) -> FastAPI:
     """Create FastAPI app with all routes."""
+    # Bring the store to the current schema on open: a legacy studio.db (written
+    # before #26) may still hold "approve" rows. Migrating here — not folding at
+    # each read site — means every endpoint below reads one canonical vocabulary.
+    with sqlite3.connect(db_path) as conn:
+        migrate_decision_vocab(conn)
+
     app = FastAPI(title="FastHooks Studio", version="0.1.0")
 
     # CORS for local development
@@ -363,20 +370,14 @@ def create_app(db_path: Path) -> FastAPI:
         total_hooks = conn.execute("SELECT COUNT(DISTINCT hook_id) FROM events").fetchone()[0]
         total_sessions = conn.execute("SELECT COUNT(DISTINCT session_id) FROM events").fetchone()[0]
 
-        # Decision breakdown
+        # Decision breakdown (the store is already canonical — migrated on open).
         decisions = conn.execute("""
-            SELECT
-                CASE WHEN decision = 'approve' THEN 'allow' ELSE decision END
-                    AS decision,
-                COUNT(*) as count
+            SELECT decision, COUNT(*) as count
             FROM events
             WHERE event_type = 'handler_end' AND decision IS NOT NULL
-            GROUP BY 1
+            GROUP BY decision
         """).fetchall()
 
-        # The CASE folds the deprecated "approve" into "allow" so the breakdown is
-        # coherent even on a studio.db whose rows predate the migration (the
-        # read-only server never runs the observer's one-time migration).
         decision_counts = {row["decision"]: row["count"] for row in decisions}
 
         # Average handler duration

--- a/src/fasthooks/testing/strategy_client.py
+++ b/src/fasthooks/testing/strategy_client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fasthooks.depends import State, Transcript
+from fasthooks.observability import Decision
 from fasthooks.testing.mocks import MockEvent
 
 if TYPE_CHECKING:
@@ -402,12 +403,17 @@ class StrategyTestClient:
             ), f"No block with '{reason_contains}' in reason. Reasons: {reasons}"
 
     def assert_allowed(self) -> None:
-        """Assert that an allow/approve decision was made."""
+        """Assert that an allow decision was made.
+
+        Strategies record the canonical observability vocabulary (#26), so an
+        allowed path emits ``Decision.ALLOW``. ``Decision`` is a str-enum, so the
+        comparison also matches a legacy raw ``"allow"`` row.
+        """
         decisions = [e for e in self._events if e.event_type == "decision"]
-        approves = [e for e in decisions if getattr(e, "decision", None) == "approve"]
+        allows = [e for e in decisions if getattr(e, "decision", None) == Decision.ALLOW]
 
         decisions_list = [getattr(e, "decision", None) for e in decisions]
-        assert approves, f"No approve decisions found. Decisions: {decisions_list}"
+        assert allows, f"No allow decisions found. Decisions: {decisions_list}"
 
     def assert_event_emitted(
         self, custom_event_type: str, **payload_match: Any

--- a/tests/strategies/test_observability.py
+++ b/tests/strategies/test_observability.py
@@ -113,6 +113,17 @@ class TestEventEmission:
         assert decision.decision == "allow"
         assert decision.message == "observed"
 
+    def test_assert_allowed_passes_on_allow_decision(self, tmp_path: Path):
+        """The public assert_allowed() helper matches the canonical 'allow' (#26).
+
+        Regression: strategies record 'allow' (not the deprecated 'approve'), so a
+        helper filtering for 'approve' would wrongly fail on a genuinely allowed
+        path. No other test exercises this helper.
+        """
+        client = StrategyTestClient(ObservableStrategy(), project_dir=tmp_path)
+        client.trigger_stop()
+        client.assert_allowed()  # raises AssertionError if the filter drifts
+
     def test_hook_exit_has_duration(self, tmp_path: Path):
         """hook_exit event includes duration_ms."""
         strategy = ObservableStrategy()

--- a/tests/strategies/test_observability.py
+++ b/tests/strategies/test_observability.py
@@ -110,7 +110,7 @@ class TestEventEmission:
 
         decision = decisions[0]
         assert hasattr(decision, "decision")
-        assert decision.decision == "approve"
+        assert decision.decision == "allow"
         assert decision.message == "observed"
 
     def test_hook_exit_has_duration(self, tmp_path: Path):
@@ -298,7 +298,7 @@ class TestVerbosityFiltering:
             session_id="test",
             strategy_name="test",
             hook_name="on_stop",
-            decision="approve",
+            decision="allow",
         ))
         backend.handle_event(ObservabilityEvent(
             session_id="test",
@@ -327,7 +327,7 @@ class TestVerbosityFiltering:
             session_id="test",
             strategy_name="test",
             hook_name="on_stop",
-            decision="approve",
+            decision="allow",
         ))
 
         assert backend.pending_count == 2

--- a/tests/test_decision_vocab.py
+++ b/tests/test_decision_vocab.py
@@ -1,0 +1,139 @@
+"""Decision-vocabulary unification (#26).
+
+One canonical vocabulary (allow/deny/block/ask) is recorded across the
+observability boundary, regardless of which code path produced the row. The
+deprecated "approve" is folded into "allow" (the modern protocol term).
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fasthooks import HookApp, allow, ask, block, deny, deny_permission
+from fasthooks.observability import Decision, EventCapture, normalize_decision
+from fasthooks.observability.events import HookObservabilityEvent
+from fasthooks.observability.observers.sqlite import SQLiteObserver
+from fasthooks.testing import MockEvent, TestClient
+
+
+def _handler_end_decision(response: object) -> object:
+    """Record the handler_end decision for a handler returning ``response``."""
+    app = HookApp()
+    obs = EventCapture()
+    app.add_observer(obs)
+
+    @app.pre_tool("Bash")
+    def handler(event):
+        return response
+
+    TestClient(app).send(MockEvent.bash("ls"))
+    ends = [e for e in obs.events if e.event_type == "handler_end"]
+    return ends[0].decision
+
+
+@pytest.mark.parametrize(
+    "response, expected",
+    [
+        (None, "allow"),  # handler returned nothing -> allowed
+        (allow(), "allow"),  # allow() decision is "approve" internally -> "allow"
+        (deny("x"), "deny"),
+        (block("x"), "block"),
+        (ask("x"), "ask"),
+    ],
+)
+def test_handler_end_records_canonical_vocabulary(response, expected):
+    assert _handler_end_decision(response) == expected
+    # never the deprecated term
+    assert _handler_end_decision(response) != "approve"
+
+
+# ── normalize_decision unit cases ────────────────────────────────────────────
+
+def test_permission_deny_records_deny_not_allow():
+    """PermissionHookResponse uses .behavior; a deny must not default to allow."""
+    assert normalize_decision(deny_permission("nope")) is Decision.DENY
+
+
+def test_approve_is_folded_into_allow():
+    assert normalize_decision("approve") is Decision.ALLOW
+    assert normalize_decision(allow(), default=Decision.ALLOW) is Decision.ALLOW
+
+
+def test_unknown_decision_passes_through_not_masked_as_allow():
+    """A miswrite stays visible in the data rather than masquerading as allow."""
+    assert normalize_decision("weird") == "weird"
+
+
+def test_none_default_is_caller_controlled():
+    assert normalize_decision(None) is None  # absent
+    assert normalize_decision(None, default=Decision.ALLOW) is Decision.ALLOW
+
+
+# ── model validator (crash-safe coercion at construction) ────────────────────
+
+def test_event_validator_coerces_approve_to_allow():
+    e = HookObservabilityEvent(
+        event_type="handler_end",
+        hook_id="h",
+        session_id="s",
+        hook_event_name="PreToolUse",
+        decision="approve",
+    )
+    assert e.decision is Decision.ALLOW
+
+
+def test_event_validator_never_raises_on_stray_value():
+    """Observability is constructed outside a try in _emit; it must not raise."""
+    e = HookObservabilityEvent(
+        event_type="handler_end",
+        hook_id="h",
+        session_id="s",
+        hook_event_name="PreToolUse",
+        decision="something_unexpected",
+    )
+    assert e.decision == "something_unexpected"  # surfaced, not crashed
+
+
+# ── one-time SQLite migration ────────────────────────────────────────────────
+
+def test_sqlite_migration_folds_approve_once():
+    with tempfile.TemporaryDirectory() as d:
+        dbp = Path(d) / "studio.db"
+        conn = sqlite3.connect(dbp)
+        conn.execute(
+            "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "event_type TEXT NOT NULL, hook_id TEXT NOT NULL, timestamp REAL NOT NULL, "
+            "session_id TEXT NOT NULL, hook_event_name TEXT NOT NULL, tool_name TEXT, "
+            "handler_name TEXT, duration_ms REAL, decision TEXT, reason TEXT, "
+            "input_preview TEXT, error_type TEXT, error_message TEXT, skip_reason TEXT)"
+        )
+        for dec in ("approve", "approve", "deny"):
+            conn.execute(
+                "INSERT INTO events (event_type,hook_id,timestamp,session_id,"
+                "hook_event_name,decision) VALUES ('handler_end','h',1.0,'s','PreToolUse',?)",
+                (dec,),
+            )
+        conn.commit()
+        conn.close()
+
+        SQLiteObserver(db_path=dbp)  # triggers gated migration
+
+        conn = sqlite3.connect(dbp)
+        counts = dict(conn.execute("SELECT decision, COUNT(*) FROM events GROUP BY decision"))
+        assert counts == {"allow": 2, "deny": 1}
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+        # gated: a new approve inserted later is NOT re-migrated
+        conn.execute(
+            "INSERT INTO events (event_type,hook_id,timestamp,session_id,"
+            "hook_event_name,decision) VALUES ('handler_end','h',1.0,'s','PreToolUse','approve')"
+        )
+        conn.commit()
+        conn.close()
+        SQLiteObserver(db_path=dbp)
+        conn = sqlite3.connect(dbp)
+        counts = dict(conn.execute("SELECT decision, COUNT(*) FROM events GROUP BY decision"))
+        assert counts["approve"] == 1  # untouched after the one-time migration

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -1,0 +1,60 @@
+"""Studio FastAPI server tests (needs the `studio` extra + httpx TestClient)."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+from starlette.testclient import TestClient  # noqa: E402
+
+from fasthooks.studio.server import create_app  # noqa: E402
+
+_SCHEMA = (
+    "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+    "event_type TEXT NOT NULL, hook_id TEXT NOT NULL, timestamp REAL NOT NULL, "
+    "session_id TEXT NOT NULL, hook_event_name TEXT NOT NULL, tool_name TEXT, "
+    "handler_name TEXT, duration_ms REAL, decision TEXT, reason TEXT, "
+    "input_preview TEXT, error_type TEXT, error_message TEXT, skip_reason TEXT)"
+)
+
+
+def _seed(db_path: Path, decisions: list[str]) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(_SCHEMA)
+    for dec in decisions:
+        conn.execute(
+            "INSERT INTO events (event_type,hook_id,timestamp,session_id,"
+            "hook_event_name,decision) VALUES ('handler_end','h',1.0,'s','PreToolUse',?)",
+            (dec,),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_stats_folds_approve_into_allow_on_read(tmp_path: Path):
+    """The reader must show one vocabulary even on a pre-migration DB.
+
+    The read-only studio server never runs the observer's one-time migration, so
+    get_stats folds the deprecated 'approve' into 'allow' in its aggregation —
+    otherwise a human looking at the decisions breakdown sees two buckets for one
+    concept (the exact symptom of #26).
+    """
+    db = tmp_path / "studio.db"
+    _seed(db, ["approve", "approve", "allow", "deny", "block"])
+
+    stats = TestClient(create_app(db)).get("/api/stats").json()
+
+    assert stats["decisions"] == {"allow": 3, "deny": 1, "block": 1}
+    assert "approve" not in stats["decisions"]
+    # deny_rate counts deny + block over all decisions
+    assert stats["decisions"]["deny"] + stats["decisions"]["block"] == 2
+
+
+def test_stats_empty_db(tmp_path: Path):
+    db = tmp_path / "studio.db"
+    _seed(db, [])
+    stats = TestClient(create_app(db)).get("/api/stats").json()
+    assert stats["decisions"] == {}
+    assert stats["deny_rate"] == 0

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -33,22 +33,30 @@ def _seed(db_path: Path, decisions: list[str]) -> None:
     conn.close()
 
 
-def test_stats_folds_approve_into_allow_on_read(tmp_path: Path):
-    """The reader must show one vocabulary even on a pre-migration DB.
+def test_create_app_migrates_legacy_db_on_open(tmp_path: Path):
+    """Opening a pre-#26 studio.db converges the store on one vocabulary.
 
-    The read-only studio server never runs the observer's one-time migration, so
-    get_stats folds the deprecated 'approve' into 'allow' in its aggregation —
-    otherwise a human looking at the decisions breakdown sees two buckets for one
-    concept (the exact symptom of #26).
+    create_app runs the one-time migration so the deprecated 'approve' becomes
+    'allow' in the rows themselves — every read path (stats and the detail
+    endpoints) then sees canonical values with no per-query folding. We assert
+    the data was rewritten, not that a single endpoint papered over it.
     """
     db = tmp_path / "studio.db"
     _seed(db, ["approve", "approve", "allow", "deny", "block"])
 
-    stats = TestClient(create_app(db)).get("/api/stats").json()
+    client = TestClient(create_app(db))
 
+    # The migration rewrote the rows and stamped the schema version.
+    conn = sqlite3.connect(db)
+    rows = dict(conn.execute("SELECT decision, COUNT(*) FROM events GROUP BY decision"))
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+    conn.close()
+    assert rows == {"allow": 3, "deny": 1, "block": 1}
+    assert "approve" not in rows
+
+    # ...so the aggregate read reflects one vocabulary too.
+    stats = client.get("/api/stats").json()
     assert stats["decisions"] == {"allow": 3, "deny": 1, "block": 1}
-    assert "approve" not in stats["decisions"]
-    # deny_rate counts deny + block over all decisions
     assert stats["decisions"]["deny"] + stats["decisions"]["block"] == 2
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-05-22T19:48:48.249933Z"
+exclude-newer = "2026-05-24T08:03:41.723261Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -468,6 +468,7 @@ studio = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -498,6 +499,7 @@ provides-extras = ["claude", "server", "reload", "studio"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.19.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },


### PR DESCRIPTION
## Summary

Unifies the allow/approve decision vocabulary across the observability boundary (closes #26). The same "allowed" outcome was recorded as `allow` (app `handler_end` default for a `None` response) **or** `approve` (`allow()`→`HookResponse.decision`, and the strategy `DecisionEvent`), so `studio.db` mixed both for one concept.

**Canonical = `allow`** — the modern protocol term (`permissionDecision` allow/deny/ask); `approve` is the deprecated wire value. (The issue's parenthetical had this backwards — verified against hooks.md.) `HookResponse.decision` keeps `approve` internally, correct at the protocol layer; only the observability record is normalized.

## Changes

| Layer | Change |
|-------|--------|
| **Vocabulary** | `Decision(str, Enum)` {allow/deny/block/ask} + one `normalize_decision()` (response/string/None → canonical), exported as public API |
| **Write paths** | `app.py` handler_end/hook_end + strategies' `DecisionEvent` all normalize. `None` is caller-controlled via `default=` (handler_end→ALLOW, hook_end→absent). Also **fixes permission-deny** (was lost → now `deny`) |
| **Crash-safety** | `before`-validator on both event models coerces `approve`→`allow` and never raises (`_emit` constructs outside a try → must fail-open) |
| **Anomaly safety** | unknown values pass **through** (visible in data), not masked as the permissive `allow` |
| **Migration (write DBs)** | one-time `UPDATE approve→allow` in the observer, gated on `PRAGMA user_version` (no full-scan per connect) |
| **Migration (read path)** | `get_stats` folds `approve`→`allow` in its `CASE`/`GROUP BY` — the symptom was surviving in the studio UI on un-migrated DBs |

## Tests

12 new decision-vocab tests + the first 2 studio endpoint tests (added `httpx` to dev deps, unblocking future studio testing). **703 pass**, ruff + mypy clean. Verified empirically: write paths, gated migration heals-once, read-fold, permission-deny, reason-still-records.
