### PR TITLE
refactor(transcript): introduce MessageEntry layer, dedupe FileHistorySnapshot (#25)

### DIFF
--- a/docs/api/transcript.md
+++ b/docs/api/transcript.md
@@ -49,16 +49,16 @@ Transcript(
 ### CRUD Methods
 
 ```python
-# Insert
-transcript.insert(index: int, entry: Entry) -> None
-transcript.append(entry: Entry) -> None
+# Insert (graph operations take a MessageEntry — the entry must carry a uuid)
+transcript.insert(index: int, entry: MessageEntry) -> None
+transcript.append(entry: MessageEntry) -> None
 
 # Remove
-transcript.remove(entry: Entry, relink: bool = True) -> None
-transcript.remove_tree(entry: Entry) -> list[Entry]
+transcript.remove(entry: MessageEntry, relink: bool = True) -> None
+transcript.remove_tree(entry: MessageEntry) -> list[MessageEntry]
 
 # Replace
-transcript.replace(old: Entry, new: Entry) -> None
+transcript.replace(old: MessageEntry, new: MessageEntry) -> None
 
 # Persistence
 transcript.load() -> None
@@ -82,13 +82,13 @@ transcript.query(
 ### Lookup Methods
 
 ```python
-transcript.find_by_uuid(uuid: str) -> Entry | None
+transcript.find_by_uuid(uuid: str) -> MessageEntry | None
 transcript.find_tool_use(tool_use_id: str) -> ToolUseBlock | None
 transcript.find_tool_result(tool_use_id: str) -> ToolResultBlock | None
 transcript.find_snapshot(message_id: str) -> FileHistorySnapshot | None
-transcript.get_parent(entry: Entry) -> Entry | None
-transcript.get_children(entry: Entry) -> list[Entry]
-transcript.get_logical_parent(entry: Entry) -> Entry | None
+transcript.get_parent(entry: MessageEntry) -> MessageEntry | None
+transcript.get_children(entry: MessageEntry) -> list[MessageEntry]
+transcript.get_logical_parent(entry: MessageEntry) -> MessageEntry | None
 ```
 
 ### Export Methods
@@ -191,9 +191,26 @@ query.exists() -> bool
 
 ### Entry (Base)
 
+`Entry` is the base for *any* JSONL stream record — messages and bookkeeping
+alike. It holds only what every record shares; the conversation-graph fields live
+on `MessageEntry` so non-message records (e.g. `FileHistorySnapshot`) don't
+inherit them.
+
 ```python
 class Entry:
     type: str
+    # + JSONL (de)serialization (to_dict) and internal line tracking
+```
+
+### MessageEntry
+
+A record that participates in the conversation graph (carries `uuid`/`parent_uuid`
+and session metadata). `UserMessage`, `AssistantMessage`, and `SystemEntry` extend
+it. `isinstance(e, MessageEntry)` means "has graph identity" — the discriminator
+that separates messages from `FileHistorySnapshot`.
+
+```python
+class MessageEntry(Entry):
     uuid: str
     parent_uuid: str | None
     timestamp: datetime | None
@@ -208,7 +225,7 @@ class Entry:
 ### UserMessage
 
 ```python
-class UserMessage(Entry):
+class UserMessage(MessageEntry):
     type: Literal["user"] = "user"
 
     # Properties
@@ -223,8 +240,8 @@ class UserMessage(Entry):
         cls,
         content: str,
         *,
-        parent: Entry | None = None,
-        context: Entry | None = None,
+        parent: MessageEntry | None = None,
+        context: MessageEntry | None = None,
         **overrides
     ) -> UserMessage
 ```
@@ -232,7 +249,7 @@ class UserMessage(Entry):
 ### AssistantMessage
 
 ```python
-class AssistantMessage(Entry):
+class AssistantMessage(MessageEntry):
     type: Literal["assistant"] = "assistant"
     request_id: str
 
@@ -253,8 +270,8 @@ class AssistantMessage(Entry):
         cls,
         content: str | list[ContentBlock],
         *,
-        parent: Entry | None = None,
-        context: Entry | None = None,
+        parent: MessageEntry | None = None,
+        context: MessageEntry | None = None,
         model: str = "synthetic",
         stop_reason: str = "end_turn",
         **overrides
@@ -264,7 +281,7 @@ class AssistantMessage(Entry):
 ### SystemEntry
 
 ```python
-class SystemEntry(Entry):
+class SystemEntry(MessageEntry):
     type: Literal["system"] = "system"
     subtype: str
     content: str

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,20 +233,24 @@ class Transcript:
 ### Entry Types
 
 ```
-TranscriptEntry (union type)
-├── UserMessage         # User input
-├── AssistantMessage    # Claude response (may contain tool_use blocks)
-├── SystemEntry         # System messages, summaries
-└── FileHistorySnapshot # File state snapshots (not an Entry subclass)
+Entry                       # base: any JSONL record (type, to_dict)
+├── MessageEntry            # graph record (uuid, parent_uuid, session meta)
+│   ├── UserMessage         # User input
+│   ├── AssistantMessage    # Claude response (may contain tool_use blocks)
+│   └── SystemEntry         # System messages, summaries
+└── FileHistorySnapshot     # File state snapshots (Entry, but NOT a MessageEntry)
 ```
+
+`isinstance(e, MessageEntry)` is the "is a graph record" discriminator;
+`FileHistorySnapshot` is excluded because it has no uuid/parent.
 
 ### Indexing
 
 Transcript maintains indexes for fast lookups:
 
 ```python
-self._by_uuid: dict[str, Entry] = {}           # UUID → Entry
-self._children: dict[str, list[Entry]] = {}    # parent_uuid → children
+self._by_uuid: dict[str, MessageEntry] = {}        # UUID → graph record
+self._children: dict[str, list[MessageEntry]] = {} # parent_uuid → children
 ```
 
 ---

--- a/src/fasthooks/transcript/__init__.py
+++ b/src/fasthooks/transcript/__init__.py
@@ -14,6 +14,7 @@ from fasthooks.transcript.entries import (
     CompactBoundary,
     Entry,
     FileHistorySnapshot,
+    MessageEntry,
     StopHookSummary,
     SystemEntry,
     TranscriptEntry,
@@ -40,6 +41,7 @@ __all__ = [
     "parse_content_block",
     # Entries
     "Entry",
+    "MessageEntry",
     "UserMessage",
     "AssistantMessage",
     "SystemEntry",

--- a/src/fasthooks/transcript/core.py
+++ b/src/fasthooks/transcript/core.py
@@ -11,8 +11,8 @@ from fasthooks.transcript.blocks import ToolResultBlock, ToolUseBlock
 from fasthooks.transcript.entries import (
     AssistantMessage,
     CompactBoundary,
-    Entry,
     FileHistorySnapshot,
+    MessageEntry,
     SystemEntry,
     TranscriptEntry,
     UserMessage,
@@ -58,7 +58,7 @@ class Transcript:
         # Indexes for fast lookups
         self._tool_use_index: dict[str, ToolUseBlock] = {}
         self._tool_result_index: dict[str, ToolResultBlock] = {}
-        self._uuid_index: dict[str, Entry] = {}
+        self._uuid_index: dict[str, MessageEntry] = {}
         self._request_id_index: dict[str, list[AssistantMessage]] = {}
         self._snapshot_index: dict[str, FileHistorySnapshot] = {}
 
@@ -130,7 +130,7 @@ class Transcript:
     def _index_entry(self, entry: TranscriptEntry) -> None:
         """Add entry to lookup indexes."""
         # UUID index (only for Entry subclasses)
-        if isinstance(entry, Entry) and entry.uuid:
+        if isinstance(entry, MessageEntry) and entry.uuid:
             self._uuid_index[entry.uuid] = entry
 
         # Tool use/result indexes + request_id index
@@ -163,21 +163,24 @@ class Transcript:
         """Find ToolResultBlock by tool_use_id."""
         return self._tool_result_index.get(tool_use_id)
 
-    def find_by_uuid(self, uuid: str) -> Entry | None:
-        """Find entry by UUID (searches both current and archived)."""
+    def find_by_uuid(self, uuid: str) -> MessageEntry | None:
+        """Find entry by UUID (searches both current and archived).
+
+        Only graph records (MessageEntry) carry a uuid, so the result is one.
+        """
         return self._uuid_index.get(uuid)
 
     def find_snapshot(self, message_id: str) -> FileHistorySnapshot | None:
         """Find file history snapshot by message_id."""
         return self._snapshot_index.get(message_id)
 
-    def get_parent(self, entry: Entry) -> Entry | None:
+    def get_parent(self, entry: MessageEntry) -> MessageEntry | None:
         """Get parent entry via parent_uuid (searches both current and archived)."""
         if entry.parent_uuid:
             return self.find_by_uuid(entry.parent_uuid)
         return None
 
-    def get_logical_parent(self, entry: Entry) -> Entry | None:
+    def get_logical_parent(self, entry: MessageEntry) -> MessageEntry | None:
         """Get logical parent, handling compact boundaries.
 
         For CompactBoundary entries, returns the entry referenced by
@@ -189,8 +192,8 @@ class Transcript:
         return self.get_parent(entry)
 
     def get_children(
-        self, entry: Entry, include_archived: bool | None = None
-    ) -> list[Entry]:
+        self, entry: MessageEntry, include_archived: bool | None = None
+    ) -> list[MessageEntry]:
         """Get all entries with this entry as parent.
 
         Args:
@@ -202,7 +205,7 @@ class Transcript:
 
         source = self._archived + self.entries if include_archived else self.entries
         return [
-            e for e in source if isinstance(e, Entry) and e.parent_uuid == entry.uuid
+            e for e in source if isinstance(e, MessageEntry) and e.parent_uuid == entry.uuid
         ]
 
     def get_entries_by_request_id(self, request_id: str) -> list[AssistantMessage]:
@@ -373,7 +376,7 @@ class Transcript:
 
         source = self._get_source(include_archived)
         # Use UUIDs for membership check (entries aren't hashable)
-        source_uuids = {e.uuid for e in source if isinstance(e, Entry) and e.uuid}
+        source_uuids = {e.uuid for e in source if isinstance(e, MessageEntry) and e.uuid}
 
         result = []
         seen: set[str] = set()
@@ -445,7 +448,7 @@ class Transcript:
             self._archived = archived_snapshot
             raise
 
-    def remove(self, entry: Entry, relink: bool = True) -> None:
+    def remove(self, entry: MessageEntry, relink: bool = True) -> None:
         """Remove entry from transcript.
 
         Args:
@@ -459,13 +462,13 @@ class Transcript:
         if relink:
             # Relink children to entry's parent
             for e in self.entries:
-                if isinstance(e, Entry) and e.parent_uuid == entry.uuid:
+                if isinstance(e, MessageEntry) and e.parent_uuid == entry.uuid:
                     e.parent_uuid = entry.parent_uuid
 
         self.entries.remove(entry)
         self._remove_from_indexes(entry)
 
-    def remove_tree(self, entry: Entry) -> list[Entry]:
+    def remove_tree(self, entry: MessageEntry) -> list[MessageEntry]:
         """Remove entry and all descendants.
 
         Returns list of removed entries.
@@ -483,7 +486,7 @@ class Transcript:
                 children = [
                     e
                     for e in self.entries
-                    if isinstance(e, Entry) and e.parent_uuid == current.uuid
+                    if isinstance(e, MessageEntry) and e.parent_uuid == current.uuid
                 ]
                 to_remove.extend(children)
                 self.entries.remove(current)
@@ -492,7 +495,7 @@ class Transcript:
 
         return removed
 
-    def insert(self, index: int, entry: Entry) -> None:
+    def insert(self, index: int, entry: MessageEntry) -> None:
         """Insert entry at position, rewiring parent_uuid chain.
 
         The new entry's parent_uuid is set to the previous entry's uuid.
@@ -504,7 +507,7 @@ class Transcript:
         # Set new entry's parent
         if index > 0:
             prev_entry = self.entries[index - 1]
-            if isinstance(prev_entry, Entry):
+            if isinstance(prev_entry, MessageEntry):
                 entry.parent_uuid = prev_entry.uuid
         else:
             # Inserting at start - explicitly set no parent
@@ -513,26 +516,26 @@ class Transcript:
         # Relink the entry that will follow
         if index < len(self.entries):
             next_entry = self.entries[index]
-            if isinstance(next_entry, Entry):
+            if isinstance(next_entry, MessageEntry):
                 next_entry.parent_uuid = entry.uuid
 
         self.entries.insert(index, entry)
         self._index_entry(entry)
 
-    def append(self, entry: Entry) -> None:
+    def append(self, entry: MessageEntry) -> None:
         """Add entry to end of transcript.
 
         Sets parent_uuid to last entry's uuid.
         """
         if self.entries:
             last = self.entries[-1]
-            if isinstance(last, Entry):
+            if isinstance(last, MessageEntry):
                 entry.parent_uuid = last.uuid
 
         self.entries.append(entry)
         self._index_entry(entry)
 
-    def replace(self, old: Entry, new: Entry) -> None:
+    def replace(self, old: MessageEntry, new: MessageEntry) -> None:
         """Replace entry, preserving position in chain.
 
         The new entry inherits old's parent_uuid.
@@ -546,7 +549,7 @@ class Transcript:
 
         # Relink children
         for e in self.entries:
-            if isinstance(e, Entry) and e.parent_uuid == old.uuid:
+            if isinstance(e, MessageEntry) and e.parent_uuid == old.uuid:
                 e.parent_uuid = new.uuid
 
         self.entries[idx] = new
@@ -555,7 +558,7 @@ class Transcript:
 
     def _remove_from_indexes(self, entry: TranscriptEntry) -> None:
         """Remove entry from lookup indexes."""
-        if isinstance(entry, Entry) and entry.uuid:
+        if isinstance(entry, MessageEntry) and entry.uuid:
             self._uuid_index.pop(entry.uuid, None)
 
         if isinstance(entry, AssistantMessage):

--- a/src/fasthooks/transcript/entries.py
+++ b/src/fasthooks/transcript/entries.py
@@ -22,7 +22,15 @@ if TYPE_CHECKING:
 
 
 class Entry(BaseModel):
-    """Base class for all transcript entries."""
+    """Base for *any* JSONL stream record — messages and bookkeeping alike.
+
+    Holds only what every record shares: the ``type`` discriminator, the internal
+    line number, and JSONL (de)serialization. The conversation-graph fields
+    (uuid, parent_uuid, session metadata) live on :class:`MessageEntry`, so a
+    non-message record like :class:`FileHistorySnapshot` does not inherit — and
+    therefore does not re-serialize — a dozen empty ``uuid``/``sessionId``/``cwd``
+    fields it never had on the wire.
+    """
 
     model_config = ConfigDict(
         extra="allow",  # Preserve unknown fields
@@ -31,17 +39,6 @@ class Entry(BaseModel):
     )
 
     type: str = ""
-    uuid: str = ""
-    parent_uuid: str | None = Field(default=None, alias="parentUuid")
-    timestamp: datetime | None = None
-    session_id: str = Field(default="", alias="sessionId")
-    cwd: str = ""
-    version: str = ""
-    git_branch: str = Field(default="", alias="gitBranch")
-    is_sidechain: bool = Field(default=False, alias="isSidechain")
-    user_type: str = Field(default="", alias="userType")
-    slug: str = ""
-    is_synthetic: bool = Field(default=False, alias="isSynthetic")
 
     # Internal tracking
     _line_number: int | None = None
@@ -58,7 +55,34 @@ class Entry(BaseModel):
         return data
 
 
-class UserMessage(Entry):
+class MessageEntry(Entry):
+    """A record that participates in the conversation graph.
+
+    It carries ``uuid``/``parent_uuid`` plus the session metadata used to link
+    entries into a tree. Despite the name this is broader than "chat message":
+    :class:`UserMessage`, :class:`AssistantMessage`, :class:`SystemEntry` (and its
+    subtypes), and unknown-but-graph-shaped records are all ``MessageEntry``.
+
+    The ``isinstance(e, MessageEntry)`` discriminator therefore means "has graph
+    identity" — exactly what separates these from :class:`FileHistorySnapshot`,
+    which is a bare bookkeeping record with no uuid/parent. Do not re-narrow this
+    to "is a chat message" by name; that reintroduces the bug this layer fixes.
+    """
+
+    uuid: str = ""
+    parent_uuid: str | None = Field(default=None, alias="parentUuid")
+    timestamp: datetime | None = None
+    session_id: str = Field(default="", alias="sessionId")
+    cwd: str = ""
+    version: str = ""
+    git_branch: str = Field(default="", alias="gitBranch")
+    is_sidechain: bool = Field(default=False, alias="isSidechain")
+    user_type: str = Field(default="", alias="userType")
+    slug: str = ""
+    is_synthetic: bool = Field(default=False, alias="isSynthetic")
+
+
+class UserMessage(MessageEntry):
     """User's input to Claude."""
 
     type: Literal["user"] = "user"
@@ -110,8 +134,8 @@ class UserMessage(Entry):
         cls,
         content: str,
         *,
-        parent: Entry | None = None,
-        context: Entry | None = None,
+        parent: MessageEntry | None = None,
+        context: MessageEntry | None = None,
         cwd: str | None = None,
         session_id: str | None = None,
         **overrides: Any,
@@ -140,7 +164,7 @@ class UserMessage(Entry):
         }
 
         # Copy metadata from context (only if it's an Entry with these fields)
-        if ctx and isinstance(ctx, Entry):
+        if ctx and isinstance(ctx, MessageEntry):
             data["session_id"] = ctx.session_id
             data["cwd"] = ctx.cwd
             data["version"] = ctx.version
@@ -223,7 +247,7 @@ class UserMessage(Entry):
         return instance
 
 
-class AssistantMessage(Entry):
+class AssistantMessage(MessageEntry):
     """Claude's response."""
 
     type: Literal["assistant"] = "assistant"
@@ -288,8 +312,8 @@ class AssistantMessage(Entry):
         cls,
         content: str | list[ContentBlock],
         *,
-        parent: Entry | None = None,
-        context: Entry | None = None,
+        parent: MessageEntry | None = None,
+        context: MessageEntry | None = None,
         model: str = "synthetic",
         stop_reason: str = "end_turn",
         cwd: str | None = None,
@@ -323,7 +347,7 @@ class AssistantMessage(Entry):
         }
 
         # Copy metadata from context (only if it's an Entry with these fields)
-        if ctx and isinstance(ctx, Entry):
+        if ctx and isinstance(ctx, MessageEntry):
             data["session_id"] = ctx.session_id
             data["cwd"] = ctx.cwd
             data["version"] = ctx.version
@@ -416,7 +440,7 @@ class AssistantMessage(Entry):
         return instance
 
 
-class SystemEntry(Entry):
+class SystemEntry(MessageEntry):
     """System events and metadata."""
 
     type: Literal["system"] = "system"
@@ -446,26 +470,23 @@ class StopHookSummary(SystemEntry):
     tool_use_id: str = Field(default="", alias="toolUseID")
 
 
-class FileHistorySnapshot(BaseModel):
-    """Tracks file backups for undo capability. Not a message entry."""
-
-    model_config = ConfigDict(extra="allow", populate_by_name=True)
+class FileHistorySnapshot(Entry):
+    """Tracks file backups for undo capability. A bookkeeping record, *not* a
+    message: it has no uuid/parent and never participates in the conversation
+    graph. Extends :class:`Entry` (not :class:`MessageEntry`) so it reuses the
+    shared config/``_line_number``/``to_dict`` without inheriting graph fields.
+    """
 
     type: Literal["file-history-snapshot"] = "file-history-snapshot"
     message_id: str = Field(default="", alias="messageId")
     snapshot: dict[str, Any] = Field(default_factory=dict)
     is_snapshot_update: bool = Field(default=False, alias="isSnapshotUpdate")
 
-    _line_number: int | None = None
 
-    def to_dict(self) -> dict[str, Any]:
-        """Serialize to dict for JSONL output."""
-        data = self.model_dump(by_alias=True, exclude_none=True, mode="json")
-        data.pop("_line_number", None)
-        return data
-
-
-# Type alias for all entry types
+# Type alias for all entry types. MessageEntry is the catch-all: parse_entry
+# returns it for unknown types (an unrecognized record still links into the
+# graph), and FileHistorySnapshot is the one non-message record. A bare Entry is
+# never produced, so it is not a member.
 TranscriptEntry = (
     UserMessage
     | AssistantMessage
@@ -473,7 +494,7 @@ TranscriptEntry = (
     | CompactBoundary
     | StopHookSummary
     | FileHistorySnapshot
-    | Entry  # Fallback for unknown types
+    | MessageEntry  # Fallback for unknown graph-shaped records
 )
 
 
@@ -498,5 +519,7 @@ def parse_entry(
     elif entry_type == "file-history-snapshot":
         return FileHistorySnapshot.model_validate(data)
     else:
-        # Unknown type - return base Entry
-        return Entry.model_validate(data)
+        # Unknown type. Treat it as a graph record (MessageEntry, not bare Entry):
+        # an unrecognized stream record that carries uuid/parentUuid should still
+        # link into the conversation graph, matching pre-#25 behavior.
+        return MessageEntry.model_validate(data)

--- a/src/fasthooks/transcript/factories.py
+++ b/src/fasthooks/transcript/factories.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 from fasthooks.transcript.blocks import ToolResultBlock, ToolUseBlock
-from fasthooks.transcript.entries import AssistantMessage, Entry, UserMessage
+from fasthooks.transcript.entries import AssistantMessage, MessageEntry, UserMessage
 
 if TYPE_CHECKING:
     from fasthooks.transcript.core import Transcript
@@ -50,28 +50,28 @@ def inject_tool_result(
     # Generate matching tool_use_id
     tool_use_id = f"toolu_{secrets.token_hex(12)}"
 
-    # Get context entry for metadata (find last Entry, skip FileHistorySnapshot etc.)
-    context: Entry | None = None
+    # Get context entry for metadata (last message, skip FileHistorySnapshot etc.)
+    context: MessageEntry | None = None
     for e in reversed(transcript.entries):
-        if isinstance(e, Entry):
+        if isinstance(e, MessageEntry):
             context = e
             break
 
-    # Determine insertion position and parent. The parent must be a real
-    # message Entry (we read parent.uuid); records like FileHistorySnapshot
-    # are not Entry instances and carry no uuid, so we skip them.
-    parent: Entry | None
+    # Determine insertion position and parent. The parent must be a graph record
+    # (we read parent.uuid); records like FileHistorySnapshot are not
+    # MessageEntry instances and carry no uuid, so we skip them.
+    parent: MessageEntry | None
     if position == "start":
         insert_idx = 0
         parent = None
     elif position == "end":
         insert_idx = len(transcript.entries)
         prev = transcript.entries[-1] if transcript.entries else None
-        parent = prev if isinstance(prev, Entry) else None
+        parent = prev if isinstance(prev, MessageEntry) else None
     else:
         insert_idx = position
         prev = transcript.entries[insert_idx - 1] if insert_idx > 0 else None
-        parent = prev if isinstance(prev, Entry) else None
+        parent = prev if isinstance(prev, MessageEntry) else None
 
     # Create assistant message with tool use
     tool_use = ToolUseBlock(id=tool_use_id, name=tool_name, input=tool_input)

--- a/tests/test_transcript_model.py
+++ b/tests/test_transcript_model.py
@@ -7,8 +7,8 @@ import pytest
 from fasthooks.transcript import (
     AssistantMessage,
     CompactBoundary,
-    Entry,
     FileHistorySnapshot,
+    MessageEntry,
     StopHookSummary,
     SystemEntry,
     TextBlock,
@@ -289,6 +289,29 @@ class TestEntries:
         assert entry.message_id == "msg-123"
         assert entry.is_snapshot_update is True
 
+    def test_file_history_snapshot_roundtrip_has_no_graph_fields(self):
+        """A snapshot must not gain conversation-graph fields it never had.
+
+        FileHistorySnapshot is an Entry (shares config/to_dict) but NOT a
+        MessageEntry, so it carries no uuid/parent/session metadata. If those
+        fields ever leaked onto it (the naive "snapshot extends the graph base"
+        design), to_dict would serialize a dozen empty uuid/sessionId/cwd fields
+        and pollute the JSONL round-trip. Lock the field-placement decision.
+        """
+        data = {
+            "type": "file-history-snapshot",
+            "messageId": "msg-123",
+            "snapshot": {"trackedFileBackups": {}},
+            "isSnapshotUpdate": True,
+        }
+        out = parse_entry(data).to_dict()
+
+        assert out == data  # exact round-trip, nothing added
+        for graph_field in ("uuid", "parentUuid", "sessionId", "cwd", "isSidechain"):
+            assert graph_field not in out
+        # ...and the type really isn't a graph record.
+        assert not isinstance(parse_entry(data), MessageEntry)
+
     def test_field_aliases(self):
         """Field aliases (camelCase -> snake_case) should work."""
         data = {
@@ -376,7 +399,7 @@ class TestTranscriptLoading:
         # Find any entry with UUID
         all_entries = list(t.entries) + list(t.archived)
         for entry in all_entries:
-            if isinstance(entry, Entry) and entry.uuid:
+            if isinstance(entry, MessageEntry) and entry.uuid:
                 found = t.find_by_uuid(entry.uuid)
                 assert found is not None
                 assert found.uuid == entry.uuid
@@ -407,7 +430,7 @@ class TestSidechainLoading:
 
         # Should have is_sidechain=True
         for entry in t.entries:
-            if isinstance(entry, Entry):
+            if isinstance(entry, MessageEntry):
                 assert entry.is_sidechain is True
 
 
@@ -838,7 +861,7 @@ class TestCRUDOperations:
     def test_insert_rewires_chain(self, transcript_with_chain):
         """Insert should rewire parent_uuid chain."""
         t = transcript_with_chain
-        new_entry = Entry(type="system", uuid="s1")
+        new_entry = MessageEntry(type="system", uuid="s1")
         t.insert(1, new_entry)
 
         assert len(t.entries) == 5
@@ -849,7 +872,7 @@ class TestCRUDOperations:
     def test_insert_at_start(self, transcript_with_chain):
         """Insert at index 0 should have no parent."""
         t = transcript_with_chain
-        new_entry = Entry(type="system", uuid="s0")
+        new_entry = MessageEntry(type="system", uuid="s0")
         t.insert(0, new_entry)
 
         assert new_entry.parent_uuid is None
@@ -859,7 +882,7 @@ class TestCRUDOperations:
     def test_append_sets_parent(self, transcript_with_chain):
         """Append should set parent to last entry."""
         t = transcript_with_chain
-        new_entry = Entry(type="user", uuid="u3")
+        new_entry = MessageEntry(type="user", uuid="u3")
         t.append(new_entry)
 
         assert len(t.entries) == 5
@@ -869,7 +892,7 @@ class TestCRUDOperations:
         """Replace should preserve chain position."""
         t = transcript_with_chain
         old = t.find_by_uuid("a1")
-        new = Entry(type="system", uuid="replacement")
+        new = MessageEntry(type="system", uuid="replacement")
         t.replace(old, new)
 
         assert t.find_by_uuid("a1") is None
@@ -883,7 +906,7 @@ class TestCRUDOperations:
         path = t.path
 
         # Modify
-        new_entry = Entry(type="system", uuid="added")
+        new_entry = MessageEntry(type="system", uuid="added")
         t.append(new_entry)
         t.save()
 
@@ -921,7 +944,7 @@ class TestCRUDOperations:
         """Insert at index 0 should set parent_uuid to None."""
         t = transcript_with_chain
         # Create entry with existing parent_uuid
-        new_entry = Entry(type="system", uuid="s0", parent_uuid="stale_parent")
+        new_entry = MessageEntry(type="system", uuid="s0", parent_uuid="stale_parent")
         t.insert(0, new_entry)
 
         assert new_entry.parent_uuid is None  # Should be cleared


### PR DESCRIPTION
## Summary

Closes #25. `FileHistorySnapshot` copy-pasted `Entry`'s `model_config`/`_line_number`/`to_dict` but was deliberately *not* an `Entry`, because `isinstance(e, Entry)` was the "is a real message" discriminator everywhere. The naive fix (extend `Entry`) breaks that discriminator — and the issue's literal "put uuid on Entry" **pollutes the snapshot's JSONL round-trip** with a dozen empty graph fields (verified empirically before designing around it).

## The split

- **`Entry`** — base for *any* JSONL record: `type`, `_line_number`, `to_dict`, config.
- **`MessageEntry(Entry)`** — graph identity (uuid/parent_uuid/session metadata). `UserMessage`/`AssistantMessage`/`SystemEntry` extend it.
- **`FileHistorySnapshot(Entry)`** — bookkeeping record; inherits the shared machinery, no graph fields → clean round-trip.

`isinstance(e, Entry)` → `isinstance(e, MessageEntry)` at every graph site. **mypy drove the signature surface** — once graph fields moved, every `.uuid`/`.parent_uuid` access errored until corrected (`append`/`insert`/`replace`/`get_parent`/`get_children`/…), including bare annotations the grep missed.

## Beyond the ticket

- Unknown types parse to `MessageEntry` (preserves graph participation; documented deviation from the issue's "→Entry").
- Removed the now-dead `| Entry` union arm.
- Exported `MessageEntry` publicly.
- Fixed **two latent test `AttributeError`s** (bare-`Entry` fixtures that passed only by accident) + added a round-trip regression guard locking the field-placement decision.
- Fixed stale entry-hierarchy docs (`architecture.md` wrongly said "not an Entry subclass"; `api/transcript.md` signatures).

## Acceptance (from #25)

- ✅ No duplicated `model_config`/`to_dict`/`_line_number`
- ✅ `isinstance` discriminators express "is a message" positively
- ✅ mypy clean, **705 tests pass** (+1)