### PR TITLE
feat(transcript): type server_tool_use & advisor_tool_result blocks (#34)

### DIFF
--- a/src/fasthooks/transcript/__init__.py
+++ b/src/fasthooks/transcript/__init__.py
@@ -1,6 +1,8 @@
 """Rich transcript modeling for context engineering."""
 from fasthooks.transcript.blocks import (
+    AdvisorToolResultBlock,
     ContentBlock,
+    ServerToolUseBlock,
     TextBlock,
     ThinkingBlock,
     ToolResultBlock,
@@ -37,6 +39,8 @@ __all__ = [
     "ThinkingBlock",
     "ToolResultBlock",
     "ToolUseBlock",
+    "ServerToolUseBlock",
+    "AdvisorToolResultBlock",
     "UnknownBlock",
     "parse_content_block",
     # Entries

--- a/src/fasthooks/transcript/blocks.py
+++ b/src/fasthooks/transcript/blocks.py
@@ -84,6 +84,36 @@ class ThinkingBlock(BaseModel):
     signature: str = ""
 
 
+class ServerToolUseBlock(BaseModel):
+    """A server-side tool invocation (e.g. ``advisor``, ``web_search``).
+
+    Same shape as :class:`ToolUseBlock`, but the call runs on Anthropic's side
+    (ids are ``srvtoolu_…``). Added for 2.1.x transcripts.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["server_tool_use"] = "server_tool_use"
+    id: str = ""
+    name: str = ""
+    input: dict[str, Any] = Field(default_factory=dict)
+
+
+class AdvisorToolResultBlock(BaseModel):
+    """Result of a server-side ``advisor`` tool call (2.1.x).
+
+    ``content`` is the advisor payload — a dict (``{type: advisor_result, …}``),
+    string, or list depending on the result. Optional fields default to ``None``
+    so an absent field is not re-emitted on round-trip.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["advisor_tool_result"] = "advisor_tool_result"
+    tool_use_id: str | None = None
+    content: str | dict[str, Any] | list[Any] | None = None
+
+
 class UnknownBlock(BaseModel):
     """Fallback for unrecognized block types.
 
@@ -97,7 +127,15 @@ class UnknownBlock(BaseModel):
 
 
 # Union type for all content blocks
-ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock | ThinkingBlock | UnknownBlock
+ContentBlock = (
+    TextBlock
+    | ToolUseBlock
+    | ToolResultBlock
+    | ThinkingBlock
+    | ServerToolUseBlock
+    | AdvisorToolResultBlock
+    | UnknownBlock
+)
 
 
 def parse_content_block(
@@ -132,6 +170,10 @@ def parse_content_block(
         return tool_result
     elif block_type == "thinking":
         return ThinkingBlock.model_validate(data)
+    elif block_type == "server_tool_use":
+        return ServerToolUseBlock.model_validate(data)
+    elif block_type == "advisor_tool_result":
+        return AdvisorToolResultBlock.model_validate(data)
     else:
         # Unknown block type - preserve original type for forward compatibility
         if validate == "strict":

--- a/tests/test_transcript_model.py
+++ b/tests/test_transcript_model.py
@@ -85,6 +85,45 @@ class TestContentBlocks:
         assert block.thinking == "Let me consider..."
         assert block.signature == "abc123xyz"
 
+    def test_server_tool_use_block(self):
+        """server_tool_use parses to a typed block, no warning, faithful round-trip.
+
+        2.1.x server-side tool calls (advisor, web_search) used to fall to
+        UnknownBlock (which warns and injects a spurious text:"" on dump). Real
+        block shape; must round-trip byte-faithful (#34).
+        """
+        import warnings
+
+        from fasthooks.transcript import ServerToolUseBlock
+
+        data = {"type": "server_tool_use", "id": "srvtoolu_017HfDL", "name": "advisor", "input": {}}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            block = parse_content_block(data)
+        assert isinstance(block, ServerToolUseBlock)
+        assert not w  # no "Unknown content block type" warning
+        assert block.name == "advisor"
+        assert block.model_dump(by_alias=True, exclude_none=True) == data  # no pollution
+
+    def test_advisor_tool_result_block(self):
+        """advisor_tool_result parses to a typed block, no warning, faithful (#34)."""
+        import warnings
+
+        from fasthooks.transcript import AdvisorToolResultBlock
+
+        data = {
+            "type": "advisor_tool_result",
+            "tool_use_id": "srvtoolu_017HfDL",
+            "content": {"type": "advisor_result", "text": "Consider an alternative."},
+        }
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            block = parse_content_block(data)
+        assert isinstance(block, AdvisorToolResultBlock)
+        assert not w
+        assert block.tool_use_id == "srvtoolu_017HfDL"
+        assert block.model_dump(by_alias=True, exclude_none=True) == data  # no pollution
+
     def test_unknown_block_type(self):
         """Unknown types should fallback to UnknownBlock and warn."""
         import warnings


### PR DESCRIPTION
## Summary

Closes #34. 2.1.x assistant messages carry server-side tool blocks (`advisor`, `web_search`) that fasthooks fell back to `UnknownBlock` for — emitting a `UserWarning` on every parse and injecting a spurious `text:""` on `to_dict` (since `UnknownBlock` declares `text`). Now typed.

## Changes

- **`ServerToolUseBlock`** — `type/id/name/input`, mirrors `ToolUseBlock` (`srvtoolu_…` ids).
- **`AdvisorToolResultBlock`** — `type/tool_use_id/content`; optional fields default to `None` so an absent field isn't re-emitted (avoids the #32 default-pollution class).
- Routed in `parse_content_block`, added to the `ContentBlock` union, exported from `fasthooks.transcript`.

Verified with **real block shapes**: each parses to the typed class (not `UnknownBlock`), raises **no warning**, and `model_dump` round-trips **byte-faithful** + schema-valid against the 2.1.144 `$defs`.

## Scope (narrowed after investigation — see [#34 comment](https://github.com/oneryalcin/fasthooks/issues/34))

After #32's wire-faithful `to_dict`, the 2.1.x **record** types (`attachment`, `permission-mode`, `pr-link`, `queue-operation`, `ai-title`, `last-prompt`, …) **already round-trip faithfully** via the `MessageEntry` fallback. Typed accessor models for them (esp. ~40 `attachment` subtypes) are **deferred** — no consumer in a hooks library; adding them would be coverage theatre. The two apparent record "failures" are **not fasthooks bugs**:
- `mode`: not in the 2.1.144 schema (newer CLI 2.1.153 emits it; raw fails too) — an agent-schemas coverage gap.
- `last-prompt` (1): source record missing its required `lastPrompt` field — malformed, faithfully preserved.

So this PR fixes the one genuine gap: the two content blocks.

## Verification

713 tests pass (+2 real-shape block tests), ruff clean, transcript module mypy-clean.