### PR TITLE
feat(cli): add `fasthooks test` — one-shot hook smoke test (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ fasthooks init                      # create .claude/hooks.py
 fasthooks install hooks.py          # register with Claude Code (--scope, --http, --auth)
 fasthooks status                    # show what's registered and validate
 fasthooks uninstall                 # remove hooks (--scope)
+fasthooks test hooks.py -e PreToolUse:Bash -i '{"command":"rm -rf /"}'  # smoke-test a hook
 fasthooks add <recipe>              # scaffold a recipe (kill-switch, steer)
 fasthooks serve hooks.py            # run as a persistent HTTP server
 fasthooks studio                    # launch the visual debugger

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,6 +317,32 @@ See the [Observability Guide](observability.md) for more details.
 
 ---
 
+### fasthooks test
+
+Run a hook file against a synthetic event — a quick smoke test, **not** your
+pytest suite. It builds a hook-event envelope and runs the file the way Claude
+Code does (stdin → hook → stdout/exit code), then reports the outcome.
+
+```bash
+fasthooks test <path> [--event NAME[:TOOL]] [--input JSON]
+```
+
+```bash
+# Does the hook block a dangerous command?
+fasthooks test .claude/hooks.py --event PreToolUse:Bash --input '{"command": "rm -rf /"}'
+# → shows the deny decision, a block (exit 2), or "allowed"
+
+# Other events; --input may be inline JSON or @file.json
+fasthooks test .claude/hooks.py -e Stop
+fasthooks test .claude/hooks.py -e PostToolUse:Edit -i @sample_input.json
+```
+
+`--event` defaults to `PreToolUse:Bash`. The command exits 0 whenever the hook
+ran (allow *or* block are both valid outcomes); non-zero only on a harness error
+(missing file, bad JSON, timeout, hook crash).
+
+---
+
 ## Scopes
 
 fasthooks supports three installation scopes:
@@ -447,18 +473,11 @@ Future CLI commands planned for v2:
 | Command | Description |
 |---------|-------------|
 | `fasthooks show-config` | Output settings.json snippet without writing (for CI/CD, debugging) |
-| `fasthooks test` | Run hooks locally with mock events (quick smoke tests) |
 
 **show-config** - Preview what `install` would write:
 ```bash
 fasthooks show-config .claude/hooks.py
 # Outputs JSON to stdout, doesn't modify any files
-```
-
-**test** - Test handlers without Claude Code:
-```bash
-fasthooks test .claude/hooks.py --event PreToolUse:Bash --input '{"command": "rm -rf /"}'
-# Output: {"decision": "deny", "reason": "Dangerous command blocked"}
 ```
 
 Have a feature request? [Open an issue](https://github.com/oneryalcin/fasthooks/issues).

--- a/docs/tutorial/testing.md
+++ b/docs/tutorial/testing.md
@@ -113,16 +113,19 @@ Run tests:
 pytest test_hooks.py -v
 ```
 
-## CLI Testing
+## CLI Smoke Test
 
-You can also test via the CLI:
+For a quick manual check (no test file needed), run a hook against a synthetic
+event with `fasthooks test`:
 
 ```bash
-# Generate test event
-fasthooks example bash_dangerous > event.json
-
-# Run hook and check output
-fasthooks run hooks.py --input event.json
+fasthooks test .claude/hooks.py --event PreToolUse:Bash --input '{"command": "rm -rf /"}'
 ```
 
-This outputs the JSON response directly, useful for quick manual testing.
+It builds a valid hook-event envelope, runs the hook the way Claude Code does
+(stdin → hook → stdout/exit code), and reports the outcome — the decision JSON, a
+block (exit 2), or "allowed". `--event` accepts `Name` or `Name:Tool` (e.g.
+`Stop`, `PostToolUse:Edit`); `--input` is the `tool_input` JSON (or `@file.json`).
+
+This is a smoke test, not your test suite — for thorough tests use `TestClient`
+and `MockEvent` as shown above.

--- a/src/fasthooks/cli/app.py
+++ b/src/fasthooks/cli/app.py
@@ -186,6 +186,35 @@ def add(
 
 
 @app.command()
+def test(
+    hook_file: Annotated[
+        str,
+        typer.Argument(help="Path to the hook file, e.g. .claude/hooks.py"),
+    ],
+    event: Annotated[
+        str,
+        typer.Option(
+            "--event",
+            "-e",
+            help="Event to send: 'PreToolUse:Bash', 'PostToolUse:Edit', 'Stop', ...",
+        ),
+    ] = "PreToolUse:Bash",
+    input_raw: Annotated[
+        str | None,
+        typer.Option(
+            "--input",
+            "-i",
+            help="tool_input as JSON (or @file.json)",
+        ),
+    ] = None,
+) -> None:
+    """Run a hook file against a synthetic event (quick smoke test — not your pytest suite)."""
+    from fasthooks.cli.commands.smoke import run_smoke
+
+    raise typer.Exit(code=run_smoke(hook_file, event, input_raw, console))
+
+
+@app.command()
 def serve(
     path: Annotated[
         str,

--- a/src/fasthooks/cli/commands/smoke.py
+++ b/src/fasthooks/cli/commands/smoke.py
@@ -1,0 +1,151 @@
+"""``fasthooks test`` — run a hook file against a synthetic event (smoke test).
+
+This drives the hook the *same way Claude Code does*: it builds a hook-event
+stdin envelope and runs the file in a subprocess, then reports the three signals
+a hook can produce — stdout JSON decision, stderr, and exit code (2 = block).
+That's the differentiated value over a programmatic ``TestClient`` test: it
+exercises the real stdin → dispatch → stdout/exit path end to end.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+_TIMEOUT_S = 10
+
+
+def _parse_event_spec(spec: str) -> tuple[str, str | None]:
+    """``'PreToolUse:Bash'`` -> ``('PreToolUse', 'Bash')``; ``'Stop'`` -> ``('Stop', None)``."""
+    name, _, tool = spec.partition(":")
+    return name, (tool or None)
+
+
+def build_event(
+    event_name: str,
+    tool_name: str | None,
+    tool_input: dict[str, Any],
+    *,
+    cwd: str,
+    transcript_path: str,
+) -> dict[str, Any]:
+    """Build a Claude Code hook stdin envelope.
+
+    Field placement mirrors :class:`MockEvent` (the programmatic test factory) so
+    the smoke-test path and the test path can't drift — pinned by
+    ``test_cli_smoke.test_envelope_matches_mockevent``.
+    """
+    event: dict[str, Any] = {
+        "session_id": "smoke-test",
+        "transcript_path": transcript_path,
+        "cwd": cwd,
+        "permission_mode": "default",
+        "hook_event_name": event_name,
+    }
+    if tool_name:
+        event["tool_name"] = tool_name
+        event["tool_input"] = tool_input
+        event["tool_use_id"] = "smoke-test-tool-use"
+        if event_name == "PostToolUse":
+            event["tool_response"] = {}
+    elif event_name == "UserPromptSubmit":
+        event["prompt"] = tool_input.get("prompt", "") if isinstance(tool_input, dict) else ""
+    elif event_name in ("Stop", "SubagentStop"):
+        event["stop_hook_active"] = False
+    return event
+
+
+def _load_input(raw: str | None, console: Console) -> dict[str, Any] | None:
+    """Parse ``--input`` (inline JSON or ``@file.json``). Returns None on error."""
+    if not raw:
+        return {}
+    text = Path(raw[1:]).read_text() if raw.startswith("@") else raw
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, OSError) as e:
+        console.print(f"[red]--input is not valid JSON:[/red] {e}")
+        return None
+    if not isinstance(parsed, dict):
+        console.print("[red]--input must be a JSON object[/red]")
+        return None
+    return parsed
+
+
+def _render(proc: subprocess.CompletedProcess[str], console: Console) -> int:
+    """Interpret the hook's three signals; return the CLI's own exit code.
+
+    The CLI exits 0 whenever the hook *ran* (allow OR block are both valid hook
+    outcomes); non-zero only when the harness or the hook itself failed.
+    """
+    out, err, code = proc.stdout.strip(), proc.stderr.strip(), proc.returncode
+
+    if code == 2:  # block: reason goes to stderr, shown to Claude
+        console.print("[red]● blocked[/red] [dim](exit 2)[/dim]")
+        if err:
+            console.print(err)
+        return 0
+    if code != 0:
+        console.print(f"[red]✗ hook errored (exit {code})[/red]")
+        if err:
+            console.print(err)
+        return code
+    if not out:
+        console.print("[green]● allowed[/green] [dim](no output)[/dim]")
+        if err:
+            console.print(f"[dim]stderr: {err}[/dim]")
+        return 0
+    try:
+        console.print_json(json.dumps(json.loads(out)))
+    except json.JSONDecodeError:
+        console.print(out)  # hook printed something non-JSON; show it raw
+    if err:
+        console.print(f"[dim]stderr: {err}[/dim]")
+    return 0
+
+
+def run_smoke(
+    hook_file: str, event_spec: str, input_raw: str | None, console: Console
+) -> int:
+    """Run ``hook_file`` against a synthetic ``event_spec`` event."""
+    hook_path = Path(hook_file)
+    if not hook_path.is_file():
+        console.print(f"[red]Hook file not found:[/red] {hook_file}")
+        return 1
+
+    tool_input = _load_input(input_raw, console)
+    if tool_input is None:
+        return 1
+
+    event_name, tool_name = _parse_event_spec(event_spec)
+
+    # An empty transcript file so handlers that take `transcript: Transcript`
+    # don't error on a bogus path — they just see an empty session.
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as tf:
+        transcript_path = tf.name
+    try:
+        event = build_event(
+            event_name, tool_name, tool_input,
+            cwd=str(Path.cwd()), transcript_path=transcript_path,
+        )
+        label = event_name + (f":{tool_name}" if tool_name else "")
+        console.print(f"[dim]→ {label} → {hook_path}[/dim]")
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(hook_path)],
+                input=json.dumps(event),
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            console.print(f"[red]✗ hook timed out after {_TIMEOUT_S}s[/red]")
+            return 1
+    finally:
+        Path(transcript_path).unlink(missing_ok=True)
+
+    return _render(proc, console)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,161 @@
+"""Tests for `fasthooks test` — the one-shot hook smoke-test command (#3)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from fasthooks.cli.app import app
+from fasthooks.cli.commands.smoke import build_event
+from fasthooks.testing import MockEvent
+
+runner = CliRunner()
+
+_DENY_HOOK = '''\
+from fasthooks import HookApp, deny
+app = HookApp()
+
+@app.pre_tool("Bash")
+def block_rm(event):
+    if "rm -rf" in event.command:
+        return deny("Dangerous command blocked")
+
+if __name__ == "__main__":
+    app.run()
+'''
+
+_EXIT2_HOOK = '''\
+import sys
+sys.stderr.write("blocked via exit 2\\n")
+sys.exit(2)
+'''
+
+_STOP_HOOK = '''\
+from fasthooks import HookApp, block
+app = HookApp()
+
+@app.on_stop()
+def s(event):
+    return block("not yet")
+
+if __name__ == "__main__":
+    app.run()
+'''
+
+_POST_HOOK = '''\
+from fasthooks import HookApp
+app = HookApp()
+
+@app.post_tool("Edit")
+def p(event):
+    return None
+
+if __name__ == "__main__":
+    app.run()
+'''
+
+# A handler that takes `transcript: Transcript` must not crash on the empty
+# temp transcript the smoke runner provides.
+_TRANSCRIPT_HOOK = '''\
+from fasthooks import HookApp
+from fasthooks.depends import Transcript
+app = HookApp()
+
+@app.pre_tool("Bash")
+def t(event, transcript: Transcript):
+    _ = transcript.stats.input_tokens
+    return None
+
+if __name__ == "__main__":
+    app.run()
+'''
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.write_text(body)
+    return p
+
+
+def test_envelope_matches_mockevent():
+    """Drift guard: the CLI envelope must carry every field MockEvent emits.
+
+    Keeps the smoke-test path and the programmatic test factory from diverging on
+    hook-event field placement.
+    """
+    env = build_event(
+        "PreToolUse", "Bash", {"command": "x"},
+        cwd="/w", transcript_path="/t.jsonl",
+    )
+    mock_keys = set(MockEvent.bash("x").model_dump(by_alias=True, exclude_none=True))
+    assert mock_keys <= set(env), f"envelope missing MockEvent keys: {mock_keys - set(env)}"
+
+
+def test_deny_via_stdout_json(tmp_path):
+    """A hook that denies via deny() surfaces the decision JSON; CLI exits 0."""
+    hook = _write(tmp_path, "hooks.py", _DENY_HOOK)
+    result = runner.invoke(
+        app, ["test", str(hook), "-e", "PreToolUse:Bash", "-i", '{"command":"rm -rf /"}']
+    )
+    assert result.exit_code == 0, result.output
+    assert "deny" in result.output
+    assert "Dangerous command blocked" in result.output
+
+
+def test_allowed_when_safe(tmp_path):
+    """A non-matching command produces no output -> reported as allowed."""
+    hook = _write(tmp_path, "hooks.py", _DENY_HOOK)
+    result = runner.invoke(
+        app, ["test", str(hook), "-i", '{"command":"ls -la"}']  # default event PreToolUse:Bash
+    )
+    assert result.exit_code == 0, result.output
+    assert "allowed" in result.output
+
+
+def test_block_via_exit_2(tmp_path):
+    """The exit-2 protocol path (block + stderr) is interpreted, not dropped."""
+    hook = _write(tmp_path, "exit2.py", _EXIT2_HOOK)
+    result = runner.invoke(app, ["test", str(hook), "-i", '{"command":"x"}'])
+    assert result.exit_code == 0, result.output  # smoke test ran; hook blocked as designed
+    assert "blocked" in result.output
+    assert "blocked via exit 2" in result.output
+
+
+def test_stop_event_blocks(tmp_path):
+    """A Stop hook returning block() round-trips through the Stop envelope."""
+    hook = _write(tmp_path, "stop.py", _STOP_HOOK)
+    result = runner.invoke(app, ["test", str(hook), "-e", "Stop"])
+    assert result.exit_code == 0, result.output
+    assert "block" in result.output
+    assert "not yet" in result.output
+
+
+def test_post_tool_use_event_runs(tmp_path):
+    """The documented PostToolUse:Edit envelope parses and runs."""
+    hook = _write(tmp_path, "post.py", _POST_HOOK)
+    result = runner.invoke(
+        app, ["test", str(hook), "-e", "PostToolUse:Edit", "-i", '{"file_path":"x.py"}']
+    )
+    assert result.exit_code == 0, result.output
+    assert "allowed" in result.output
+
+
+def test_transcript_di_handler_does_not_crash(tmp_path):
+    """A handler taking `transcript: Transcript` runs against the empty transcript."""
+    hook = _write(tmp_path, "trans.py", _TRANSCRIPT_HOOK)
+    result = runner.invoke(app, ["test", str(hook), "-i", '{"command":"ls"}'])
+    assert result.exit_code == 0, result.output
+    assert "allowed" in result.output
+
+
+def test_missing_file_errors(tmp_path):
+    result = runner.invoke(app, ["test", str(tmp_path / "nope.py")])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_bad_input_json_errors(tmp_path):
+    hook = _write(tmp_path, "hooks.py", _DENY_HOOK)
+    result = runner.invoke(app, ["test", str(hook), "-i", "{not json"])
+    assert result.exit_code == 1
+    assert "not valid JSON" in result.output


### PR DESCRIPTION
## Summary

Adds `fasthooks test` — run a hook file against a synthetic event, a quick smoke test (**not** your pytest suite). It drives the hook **the way Claude Code does**: builds a hook-event stdin envelope and runs the file in a subprocess, then reports all three signals a hook can produce — stdout JSON decision, stderr, and **exit code (2 = block)**.

```bash
fasthooks test .claude/hooks.py --event PreToolUse:Bash --input '{"command":"rm -rf /"}'
# → shows the deny decision, a block (exit 2), or "allowed"
```

The end-to-end subprocess path is the differentiated value over a programmatic `TestClient` test (which users can already write) — it exercises the real stdin → dispatch → stdout/exit wiring, doesn't care what the user named their app, and runs no import side effects.

## Design
- `commands/smoke.py`: envelope builder (field placement **mirrors `MockEvent`**, pinned by a drift test) + faithful subprocess run (`sys.executable`, 10s timeout, empty temp transcript so `transcript: Transcript` handlers don't error on a bogus path).
- `--event Name[:Tool]` (default `PreToolUse:Bash`); `--input` inline JSON or `@file.json`.
- Exits 0 when the hook **ran** (allow *or* block are both valid outcomes); non-zero only on harness error (missing file, bad JSON, timeout, crash).

## Tests
Cover the **full documented matrix** so every advertised event type is one a test runs: PreToolUse deny/allow, **exit-2 block**, Stop block, PostToolUse, transcript-DI handler, plus the MockEvent envelope drift guard. **697 pass**, ruff + mypy clean.

## Docs
`tutorial/testing.md` advertised `fasthooks example`/`fasthooks run` that **never existed** → rewritten to the real command. `cli.md` `test` moved from Roadmap to shipped.

## Re #3
Closes the live part of #3. The rest is superseded by the CLI redesign (`init` ✅, `validate` → `status` ✅); a pytest-wrapper `test` with coverage is **rejected as a gimmick** — that's just `pytest`.