### PR TITLE
feat(recipes): long-running-agent harness suite — evidence-gate, evaluator-gate, heartbeat (#15)

### DIFF
--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -1,0 +1,131 @@
+# Long-Running Agent Harness — Plan & Scratchpad
+
+> **Living doc.** Captures our learnings + references for turning fasthooks into a
+> clean substrate for long-running-agent harnesses. Update as we spike/ship.
+> Tracks issue [#15](https://github.com/oneryalcin/fasthooks/issues/15).
+> Last updated: 2026-06-02.
+
+---
+
+## TL;DR / the thesis
+
+Express the harness as **composable recipes piped together**, not as a monolithic
+`LongRunningStrategy` god-class. fasthooks owns the **hook-shaped primitives**
+(gates, evaluator, heartbeat, operator controls) + the **observability stream**;
+the **loop** and the **dashboard** live *outside* fasthooks. This matches
+Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
+
+---
+
+## References
+
+| What | Where | Notes |
+|---|---|---|
+| Issue #15 | `gh issue view 15` | Original "harness via hooks" proposal (Dec 2025). Its 5 proposals are already implemented (see inventory). |
+| **cwc-long-running-agents** (official Anthropic reference) | `github.com/anthropics/cwc-long-running-agents` (cloned to `/tmp`, last commit `ad107a9` 2026-05-12) | "Example ingredients, not a turnkey harness; not maintained." 5 shell hooks + evaluator subagent + handoff CLAUDE.md. |
+| Blog: Effective Harnesses for Long-Running Agents | anthropic.com/engineering/effective-harnesses-for-long-running-agents (Nov 2025) | The 3 failure modes: one-shotting, premature victory, dirty state. |
+| Blog: Harness Design for Long-Running Application Development | anthropic.com/engineering/harness-design-long-running-apps (Mar 2026) | Unattended loop, planner, sprint contracts, rubrics, browser-verified evaluator, re-simplify on model upgrades. |
+| Booth dashboard demo ("THE AGENT" / Canopy) | `jschwar2552/cwc-2026-boot`, `localhost:6174/presenter` | Live visualization of every primitive — our showcase reference (photos in chat 2026-06-02). |
+| Claude Code built-ins | `/goal`, `/loop`, `ralph-loop` plugin, Agent SDK | The loop layer — **out of fasthooks scope**. |
+
+---
+
+## Primitive inventory: cwc reference ↔ fasthooks
+
+| Primitive (cwc) | Dashboard panel | fasthooks today | Action |
+|---|---|---|---|
+| `kill-switch.sh` (halt on `AGENT_STOP`) | operator control | ✅ `add kill-switch` recipe | keep |
+| `steer.sh` (surface `STEER.md` once) | operator control | ✅ `add steer` recipe | keep |
+| `commit-on-stop.sh` | WORK SAVED / git commits | ✅ `LongRunningStrategy.enforce_commits` | extract to recipe |
+| Agent-maintained handoff (PROGRESS) | ITS OWN NOTES | ✅ `LongRunningStrategy` (richer: dynamic context inject, initializer/coding routing, pre-compact) | extract to recipe(s) |
+| Default-FAIL contract — feature list | — | ✅ `feature_list.json` tracking | keep |
+| **Default-FAIL contract — evidence gate** (`track-read`+`verify-gate`: can't mark pass without Reading evidence) | **PROOF IT LOOKED · HARD GATE** | ❌ **missing** | **build (recipe) — highest value** |
+| **Fresh-context evaluator** (subagent PASS/NEEDS_WORK) | **SECOND OPINION · EVALUATOR** | ⚠️ **plumbing spiked** (Stop hook → subprocess → block) | build (recipe) + pollution guards |
+| **Stall / heartbeat** ("goes quiet → loop moves on") | **LAST CHECK-IN · WATCHDOG** | ⚠️ partial (could emit heartbeat; the *timeout→next* is loop) | hook emits heartbeat; loop owns timeout |
+| Token-budget warnings | — | ✅ `TokenBudgetStrategy` (100k/150k/180k) | keep |
+
+---
+
+## Spikes / proven
+
+- **Evaluator-in-a-Stop-hook (2026-06-02): PROVEN.** A fasthooks `@app.on_stop()`
+  handler shells out to an evaluator command, parses the first line as the
+  verdict, and `block()`s on anything but `PASS` (surfacing findings); allows
+  stop on `PASS`. Driven via `fasthooks test hooks.py -e Stop`. The stub script
+  is a drop-in for `claude --agent evaluator -p "<review prompt>"`.
+  - **Open / "is it polluting?":** the real `claude --agent` call risks
+    **recursion** (nested claude re-firing the Stop hook → infinite eval loop),
+    **cost**, and **latency**. Mitigations to verify: run the evaluator with a
+    **no-loop-hooks config** (its own `--settings`/agent dir), a **sentinel
+    env/file guard** so an evaluation can't trigger another, a **timeout**, and
+    fail-open if the evaluator errors (never wedge the session).
+
+---
+
+## Plan (phased — pull one thread at a time)
+
+- [ ] **P1 · `evidence-gate` recipe** — the missing star primitive. `PreToolUse`
+      on the results-file write, denied unless an evidence file (screenshot/
+      console log) was `Read` this session; consume the evidence on each gated
+      write. Reference: cwc `track-read.sh` + `verify-gate.sh` (and their listed
+      gaps to tighten). *Highest value, lowest risk, demo centerpiece.*
+- [ ] **P2 · `evaluator-gate` recipe** — productionize the spike with the
+      pollution guards above. Ships the pattern; the actual evaluator agent
+      config is the user's.
+- [ ] **P3 · `heartbeat` primitive** — emit a "still alive" signal (last
+      tool-call timestamp) via observer/State so a watchdog/dashboard can detect
+      stalls. The *timeout→next-feature* decision stays in the loop.
+- [ ] **P4 · decompose `LongRunningStrategy`** → a thin bundle of the recipes
+      above (or deprecate it in favor of `include_recipes(...)`). DX-first.
+- [ ] **P5 · dashboard showcase (separate repo)** — consumes fasthooks'
+      `SQLiteObserver`/studio event stream + on-disk artifacts (PROGRESS, git
+      log, tests.json, screenshots). fasthooks = substrate; dashboard = app.
+
+---
+
+## Boundaries / non-goals (keep fasthooks a library)
+
+- **The loop is out.** build→evaluate→rebuild orchestration and "move to next
+  feature on stall" = `/loop`, `ralph-loop`, or the Agent SDK. fasthooks ships
+  the hook primitives the loop calls, not the loop.
+- **The dashboard is a separate repo**, not in fasthooks. fasthooks only
+  guarantees the observer event contract it reads.
+- **The evaluator's agent config + prompt** are the user's; fasthooks ships the
+  gate that runs it and acts on the verdict.
+
+---
+
+## DX principles (carried from this session)
+
+- Composable recipes > god-class strategies. `app.include(recipe)` is the pipe.
+- Don't reimplement what stdlib/Claude Code already do well (no loop, no pytest
+  wrapper, no query DSL — see #24's removal for the precedent).
+- Every primitive: typed, testable in isolation, faithful (no default-field
+  pollution), and verified end-to-end (`fasthooks test` is the smoke loop).
+
+---
+
+## Existing assets to reuse (don't rebuild)
+
+- Recipes: `src/fasthooks/recipes/` (`kill_switch`, `steer`, `include_recipes`).
+- Strategies: `long_running`, `token_budget`, `clean_state` (+ `docs/strategies/`).
+- Observability: `SQLiteObserver`, `studio` (the dashboard's data feed).
+- `fasthooks test` (smoke-test command, #3) — drives any hook against a synthetic event.
+
+---
+
+## Decisions log
+
+- 2026-06-02 — Reframe harness as composable recipes, not monolithic strategy.
+- 2026-06-02 — Evaluator CAN run in a Stop hook (plumbing proven); pollution
+  guards TBD before the real `claude --agent` call.
+- 2026-06-02 — Loop + dashboard stay outside fasthooks.
+
+## Open questions
+
+- Pollution test: does a real `claude --agent evaluator -p` from a Stop hook
+  recurse / blow cost? Needs a guarded live test.
+- `evidence-gate`: tighten the cwc gaps (Bash `sed`/`jq` bypass, basename-only
+  match, any-read-unlocks-any-row) or ship the simple teaching version first?
+- Decompose vs deprecate `LongRunningStrategy` — keep as a convenience bundle, or
+  retire it for explicit `include_recipes`?

--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -39,7 +39,7 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
 | `commit-on-stop.sh` | WORK SAVED / git commits | ✅ `LongRunningStrategy.enforce_commits` | extract to recipe |
 | Agent-maintained handoff (PROGRESS) | ITS OWN NOTES | ✅ `LongRunningStrategy` (richer: dynamic context inject, initializer/coding routing, pre-compact) | extract to recipe(s) |
 | Default-FAIL contract — feature list | — | ✅ `feature_list.json` tracking | keep |
-| **Default-FAIL contract — evidence gate** (`track-read`+`verify-gate`: can't mark pass without Reading evidence) | **PROOF IT LOOKED · HARD GATE** | ❌ **missing** | **build (recipe) — highest value** |
+| **Default-FAIL contract — evidence gate** (`track-read`+`verify-gate`: can't mark pass without Reading evidence) | **PROOF IT LOOKED · HARD GATE** | ✅ **shipped** — `evidence_gate` recipe (P1) | done |
 | **Fresh-context evaluator** (subagent PASS/NEEDS_WORK) | **SECOND OPINION · EVALUATOR** | ⚠️ **plumbing spiked** (Stop hook → subprocess → block) | build (recipe) + pollution guards |
 | **Stall / heartbeat** ("goes quiet → loop moves on") | **LAST CHECK-IN · WATCHDOG** | ⚠️ partial (could emit heartbeat; the *timeout→next* is loop) | hook emits heartbeat; loop owns timeout |
 | Token-budget warnings | — | ✅ `TokenBudgetStrategy` (100k/150k/180k) | keep |
@@ -64,11 +64,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
 
 ## Plan (phased — pull one thread at a time)
 
-- [ ] **P1 · `evidence-gate` recipe** — the missing star primitive. `PreToolUse`
-      on the results-file write, denied unless an evidence file (screenshot/
-      console log) was `Read` this session; consume the evidence on each gated
-      write. Reference: cwc `track-read.sh` + `verify-gate.sh` (and their listed
-      gaps to tighten). *Highest value, lowest risk, demo centerpiece.*
+- [x] **P1 · `evidence-gate` recipe** — ✅ shipped (2026-06-02). `PreToolUse`
+      Read tracks evidence (screenshots/console-logs) into State; Write/Edit to
+      the results file is denied unless evidence was read this session, and each
+      gated write consumes it. State (JSON-backed) is the mechanism so it works
+      across separate hook processes. Faithful to cwc (simple/teaching version,
+      same documented gaps). `fasthooks add evidence-gate`. Also generalized
+      `scaffold_for` to read each recipe's first knob (was hardcoded `sentinel`).
 - [ ] **P2 · `evaluator-gate` recipe** — productionize the spike with the
       pollution guards above. Ships the pattern; the actual evaluator agent
       config is the user's.
@@ -120,12 +122,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
 - 2026-06-02 — Evaluator CAN run in a Stop hook (plumbing proven); pollution
   guards TBD before the real `claude --agent` call.
 - 2026-06-02 — Loop + dashboard stay outside fasthooks.
+- 2026-06-02 — P1 `evidence-gate`: ship the simple/faithful version (documented
+  cwc gaps), not the tightened one. Generalized `scaffold_for` for non-`sentinel`
+  knobs along the way.
 
 ## Open questions
 
 - Pollution test: does a real `claude --agent evaluator -p` from a Stop hook
-  recurse / blow cost? Needs a guarded live test.
-- `evidence-gate`: tighten the cwc gaps (Bash `sed`/`jq` bypass, basename-only
-  match, any-read-unlocks-any-row) or ship the simple teaching version first?
+  recurse / blow cost? Needs a guarded live test. (P2)
 - Decompose vs deprecate `LongRunningStrategy` — keep as a convenience bundle, or
-  retire it for explicit `include_recipes`?
+  retire it for explicit `include_recipes`? (P4)

--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -132,6 +132,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
   knobs along the way.
 - 2026-06-02 — P2 `evaluator-gate`: ship with 3 guards (recursion sentinel,
   timeout, fail-open). Plumbing + guards verified with a stub evaluator.
+- 2026-06-02 — Codex review (2 passes) caught two real failure modes, both fixed:
+  (a) evidence-gate would *deadlock* under the default `HookApp()` (NullState,
+  no persistence) — now detects NullState and **fails open + warns** (and the
+  scaffold doc requires `state_dir`); (b) evaluator-gate's fail-open missed
+  non-zero subprocess exits (`subprocess.run` doesn't raise without
+  `check=True`) — now `returncode != 0` fails open with a stderr diagnostic.
+  Both have regression tests. **Both gates degrade open on misconfiguration.**
 
 ## Open questions
 

--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -40,7 +40,7 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
 | Agent-maintained handoff (PROGRESS) | ITS OWN NOTES | ✅ `LongRunningStrategy` (richer: dynamic context inject, initializer/coding routing, pre-compact) | extract to recipe(s) |
 | Default-FAIL contract — feature list | — | ✅ `feature_list.json` tracking | keep |
 | **Default-FAIL contract — evidence gate** (`track-read`+`verify-gate`: can't mark pass without Reading evidence) | **PROOF IT LOOKED · HARD GATE** | ✅ **shipped** — `evidence_gate` recipe (P1) | done |
-| **Fresh-context evaluator** (subagent PASS/NEEDS_WORK) | **SECOND OPINION · EVALUATOR** | ⚠️ **plumbing spiked** (Stop hook → subprocess → block) | build (recipe) + pollution guards |
+| **Fresh-context evaluator** (subagent PASS/NEEDS_WORK) | **SECOND OPINION · EVALUATOR** | ✅ **shipped** — `evaluator_gate` recipe (P2), 3 guards | done |
 | **Stall / heartbeat** ("goes quiet → loop moves on") | **LAST CHECK-IN · WATCHDOG** | ⚠️ partial (could emit heartbeat; the *timeout→next* is loop) | hook emits heartbeat; loop owns timeout |
 | Token-budget warnings | — | ✅ `TokenBudgetStrategy` (100k/150k/180k) | keep |
 
@@ -71,9 +71,14 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
       across separate hook processes. Faithful to cwc (simple/teaching version,
       same documented gaps). `fasthooks add evidence-gate`. Also generalized
       `scaffold_for` to read each recipe's first knob (was hardcoded `sentinel`).
-- [ ] **P2 · `evaluator-gate` recipe** — productionize the spike with the
-      pollution guards above. Ships the pattern; the actual evaluator agent
-      config is the user's.
+- [x] **P2 · `evaluator-gate` recipe** — ✅ shipped (2026-06-02). `on_stop`
+      runs a configurable evaluator command, blocks the stop unless the first
+      output line is `PASS` (findings → next turn). Three guards: recursion
+      sentinel env (`FASTHOOKS_EVALUATOR_GATE_ACTIVE`), subprocess timeout,
+      fail-open (missing/slow/erroring evaluator never wedges the session).
+      `fasthooks add evaluator-gate`. All guards verified with a stub; a real
+      `claude --agent` live test is still worth doing but the recipe is safe by
+      design.
 - [ ] **P3 · `heartbeat` primitive** — emit a "still alive" signal (last
       tool-call timestamp) via observer/State so a watchdog/dashboard can detect
       stalls. The *timeout→next-feature* decision stays in the loop.
@@ -125,10 +130,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
 - 2026-06-02 — P1 `evidence-gate`: ship the simple/faithful version (documented
   cwc gaps), not the tightened one. Generalized `scaffold_for` for non-`sentinel`
   knobs along the way.
+- 2026-06-02 — P2 `evaluator-gate`: ship with 3 guards (recursion sentinel,
+  timeout, fail-open). Plumbing + guards verified with a stub evaluator.
 
 ## Open questions
 
-- Pollution test: does a real `claude --agent evaluator -p` from a Stop hook
-  recurse / blow cost? Needs a guarded live test. (P2)
+- Live pollution test: a real `claude --agent evaluator -p` from the gate —
+  confirm recursion sentinel + cost behave in practice. Guards make it safe by
+  design; the live run is confirmation, not a blocker.
 - Decompose vs deprecate `LongRunningStrategy` — keep as a convenience bundle, or
   retire it for explicit `include_recipes`? (P4)

--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -41,7 +41,7 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
 | Default-FAIL contract — feature list | — | ✅ `feature_list.json` tracking | keep |
 | **Default-FAIL contract — evidence gate** (`track-read`+`verify-gate`: can't mark pass without Reading evidence) | **PROOF IT LOOKED · HARD GATE** | ✅ **shipped** — `evidence_gate` recipe (P1) | done |
 | **Fresh-context evaluator** (subagent PASS/NEEDS_WORK) | **SECOND OPINION · EVALUATOR** | ✅ **shipped** — `evaluator_gate` recipe (P2), 3 guards | done |
-| **Stall / heartbeat** ("goes quiet → loop moves on") | **LAST CHECK-IN · WATCHDOG** | ⚠️ partial (could emit heartbeat; the *timeout→next* is loop) | hook emits heartbeat; loop owns timeout |
+| **Stall / heartbeat** ("goes quiet → loop moves on") | **LAST CHECK-IN · WATCHDOG** | ✅ **shipped** — `heartbeat` recipe (P3) emits the signal; loop owns timeout | done |
 | Token-budget warnings | — | ✅ `TokenBudgetStrategy` (100k/150k/180k) | keep |
 
 ---
@@ -79,9 +79,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
       `fasthooks add evaluator-gate`. All guards verified with a stub; a real
       `claude --agent` live test is still worth doing but the recipe is safe by
       design.
-- [ ] **P3 · `heartbeat` primitive** — emit a "still alive" signal (last
-      tool-call timestamp) via observer/State so a watchdog/dashboard can detect
-      stalls. The *timeout→next-feature* decision stays in the loop.
+- [x] **P3 · `heartbeat` primitive** — ✅ shipped (2026-06-02). Catch-all
+      `pre_tool` overwrites a marker file (`{ts, tool, session_id}`) on every
+      tool call; passive (never blocks/raises). A watchdog/dashboard reads the
+      freshest `ts` to detect stalls; the *timeout→next-feature* decision stays
+      in the loop. Overlaps with the observer stream (which already timestamps
+      every event) — the file is the no-DB, tail-from-a-terminal alternative.
+      `fasthooks add heartbeat`.
 - [ ] **P4 · decompose `LongRunningStrategy`** → a thin bundle of the recipes
       above (or deprecate it in favor of `include_recipes(...)`). DX-first.
 - [ ] **P5 · dashboard showcase (separate repo)** — consumes fasthooks'

--- a/src/fasthooks/recipes/__init__.py
+++ b/src/fasthooks/recipes/__init__.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 from fasthooks.recipes.evaluator_gate import evaluator_gate
 from fasthooks.recipes.evidence_gate import evidence_gate
+from fasthooks.recipes.heartbeat import heartbeat
 from fasthooks.recipes.kill_switch import kill_switch
 from fasthooks.recipes.steer import steer
 
@@ -34,6 +35,7 @@ __all__ = [
     "steer",
     "evidence_gate",
     "evaluator_gate",
+    "heartbeat",
     "RECIPES",
     "scaffold_for",
     "include_recipes",
@@ -86,6 +88,16 @@ RECIPES: dict[str, RecipeSpec] = {
             "evaluator -p '...'`). On Stop it runs the evaluator and blocks "
             "unless the first output line is PASS; findings become the next "
             "turn's prompt. Fail-open + recursion-guarded."
+        ),
+    ),
+    "heartbeat": RecipeSpec(
+        factory=heartbeat,
+        summary="Write a 'still alive' marker on every tool call (stall detection).",
+        doc=(
+            "Overwrites path with {ts, tool, session_id} on each tool call so a "
+            "watchdog/dashboard can detect stalls. Passive (never blocks). If "
+            "you run the SQLiteObserver/studio you already have timestamps "
+            "there; this is the no-DB, tail-from-a-terminal alternative."
         ),
     ),
 }

--- a/src/fasthooks/recipes/__init__.py
+++ b/src/fasthooks/recipes/__init__.py
@@ -71,7 +71,11 @@ RECIPES: dict[str, RecipeSpec] = {
         doc=(
             "Point results_file at your project's results file (e.g. "
             "test-results.json). The agent must open a screenshot or console "
-            "log with the Read tool before it can write that file."
+            "log with the Read tool before it can write that file.\n\n"
+            "Requires persistent state: construct your app as "
+            "HookApp(state_dir=...) so the evidence read survives to the "
+            "separate hook process that handles the write. Without it the gate "
+            "fails open (and warns) rather than deadlocking."
         ),
     ),
     "evaluator-gate": RecipeSpec(

--- a/src/fasthooks/recipes/__init__.py
+++ b/src/fasthooks/recipes/__init__.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from fasthooks.recipes.evidence_gate import evidence_gate
 from fasthooks.recipes.kill_switch import kill_switch
 from fasthooks.recipes.steer import steer
 
@@ -27,7 +28,14 @@ if TYPE_CHECKING:
     from fasthooks.app import HookApp
     from fasthooks.blueprint import Blueprint
 
-__all__ = ["kill_switch", "steer", "RECIPES", "scaffold_for", "include_recipes"]
+__all__ = [
+    "kill_switch",
+    "steer",
+    "evidence_gate",
+    "RECIPES",
+    "scaffold_for",
+    "include_recipes",
+]
 
 
 class RecipeSpec(NamedTuple):
@@ -55,25 +63,35 @@ RECIPES: dict[str, RecipeSpec] = {
             "prompt (delivered once, then the file is removed)."
         ),
     ),
+    "evidence-gate": RecipeSpec(
+        factory=evidence_gate,
+        summary="Default-FAIL: deny marking a result passing without Reading evidence first.",
+        doc=(
+            "Point results_file at your project's results file (e.g. "
+            "test-results.json). The agent must open a screenshot or console "
+            "log with the Read tool before it can write that file."
+        ),
+    ),
 }
 
 
 def scaffold_for(name: str) -> str:
     """Build the editable config file contents for recipe ``name``.
 
-    The default arg is read from the engine's signature so the scaffold can't
-    drift from the actual default.
+    The knob (the engine's first parameter) and its default are read from the
+    signature so the scaffold can't drift from the actual default — and so each
+    recipe can name its own knob (``sentinel``, ``results_file``, ...).
     """
     spec = RECIPES[name]
     fn = spec.factory.__name__
-    default = inspect.signature(spec.factory).parameters["sentinel"].default
+    knob = next(iter(inspect.signature(spec.factory).parameters.values()))
     return (
         f'"""{name} recipe — scaffolded by `fasthooks add`. You own this; edit freely.\n'
         f"\n{spec.doc}\n"
         f'"""\n'
         f"from fasthooks.recipes import {fn}\n"
         f"\n"
-        f'recipe = {fn}(sentinel="{default}")\n'
+        f'recipe = {fn}({knob.name}="{knob.default}")\n'
     )
 
 

--- a/src/fasthooks/recipes/__init__.py
+++ b/src/fasthooks/recipes/__init__.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from fasthooks.recipes.evaluator_gate import evaluator_gate
 from fasthooks.recipes.evidence_gate import evidence_gate
 from fasthooks.recipes.kill_switch import kill_switch
 from fasthooks.recipes.steer import steer
@@ -32,6 +33,7 @@ __all__ = [
     "kill_switch",
     "steer",
     "evidence_gate",
+    "evaluator_gate",
     "RECIPES",
     "scaffold_for",
     "include_recipes",
@@ -70,6 +72,16 @@ RECIPES: dict[str, RecipeSpec] = {
             "Point results_file at your project's results file (e.g. "
             "test-results.json). The agent must open a screenshot or console "
             "log with the Read tool before it can write that file."
+        ),
+    ),
+    "evaluator-gate": RecipeSpec(
+        factory=evaluator_gate,
+        summary="Block Stop unless a fresh-context evaluator returns PASS.",
+        doc=(
+            "Edit `command` to your evaluator invocation (e.g. `claude --agent "
+            "evaluator -p '...'`). On Stop it runs the evaluator and blocks "
+            "unless the first output line is PASS; findings become the next "
+            "turn's prompt. Fail-open + recursion-guarded."
         ),
     ),
 }

--- a/src/fasthooks/recipes/evaluator_gate.py
+++ b/src/fasthooks/recipes/evaluator_gate.py
@@ -1,0 +1,80 @@
+"""Evaluator-gate recipe: a fresh-context second opinion on Stop.
+
+The builder shouldn't grade its own work. On Stop, run a separate evaluator
+(e.g. ``claude --agent evaluator -p ...``) with no memory of the build, and
+**block the stop on anything but PASS** — its findings become the next turn's
+starting point. This closes the build → evaluate → rebuild loop from the hook
+side; the loop itself is yours (``/loop``, ralph-loop, the SDK).
+
+Engine for ``fasthooks add evaluator-gate``. Mirrors the cwc reference's
+"custom Stop hook runs the evaluator as a fresh process and blocks on non-PASS."
+
+Three guards make it safe to run an LLM from inside a hook:
+
+- **recursion** — the evaluator subprocess inherits a sentinel env var; if it
+  ever re-enters this gate (e.g. the evaluator is pointed at the same hooks),
+  the gate sees the sentinel and skips, so an evaluation can't trigger another.
+- **timeout** — the subprocess is bounded.
+- **fail-open** — if the evaluator times out, is missing, or errors, the gate
+  allows the stop. A broken evaluator must never wedge the session.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+
+from fasthooks.blueprint import Blueprint
+from fasthooks.events.lifecycle import Stop
+from fasthooks.responses import HookResponse, block
+
+# Single-quote the inner prompt so the scaffolded `command="..."` stays valid.
+DEFAULT_COMMAND = (
+    "claude --agent evaluator -p "
+    "'Review the most recent commit against its spec. "
+    "Respond with PASS or NEEDS_WORK on the first line, then findings.'"
+)
+_GUARD_ENV = "FASTHOOKS_EVALUATOR_GATE_ACTIVE"
+
+
+def evaluator_gate(
+    command: str = DEFAULT_COMMAND,
+    *,
+    timeout: int = 120,
+    pass_marker: str = "PASS",
+) -> Blueprint:
+    """Block Stop unless ``command``'s first output line is ``pass_marker``.
+
+    ``command`` is the evaluator invocation (edit it to your agent/prompt); it
+    runs in the session's cwd with the recursion sentinel set. The first line of
+    stdout is the verdict; anything but ``pass_marker`` blocks the stop and
+    surfaces the remaining lines as findings.
+    """
+    bp = Blueprint("evaluator_gate")
+
+    @bp.on_stop()
+    def evaluate(event: Stop) -> HookResponse | None:
+        # Recursion guard: an evaluation must not trigger another evaluation.
+        if os.environ.get(_GUARD_ENV):
+            return None
+        try:
+            proc = subprocess.run(
+                shlex.split(command),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=event.cwd or None,
+                env={**os.environ, _GUARD_ENV: "1"},
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            # Fail open: a broken/slow/missing evaluator must not wedge the loop.
+            return None
+
+        lines = proc.stdout.strip().splitlines()
+        verdict = lines[0].strip() if lines else ""
+        if verdict == pass_marker:
+            return None
+        findings = "\n".join(lines[1:]).strip() or proc.stdout.strip()
+        return block(f"Evaluator: {verdict or 'NEEDS_WORK'}\n{findings}".rstrip())
+
+    return bp

--- a/src/fasthooks/recipes/evaluator_gate.py
+++ b/src/fasthooks/recipes/evaluator_gate.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess
+import sys
 
 from fasthooks.blueprint import Blueprint
 from fasthooks.events.lifecycle import Stop
@@ -68,6 +69,19 @@ def evaluator_gate(
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             # Fail open: a broken/slow/missing evaluator must not wedge the loop.
+            return None
+
+        if proc.returncode != 0:
+            # The evaluator started but failed (auth/config/model/CLI error) —
+            # infrastructure failure, not a NEEDS_WORK verdict. `subprocess.run`
+            # doesn't raise without check=True, so catch it here and fail open
+            # rather than block Stop forever as a bogus "NEEDS_WORK".
+            err = proc.stderr.strip()[:200]
+            print(
+                f"[fasthooks] evaluator_gate: command exited {proc.returncode}, "
+                f"allowing stop (fail-open). {err}",
+                file=sys.stderr,
+            )
             return None
 
         lines = proc.stdout.strip().splitlines()

--- a/src/fasthooks/recipes/evidence_gate.py
+++ b/src/fasthooks/recipes/evidence_gate.py
@@ -1,0 +1,77 @@
+"""Evidence-gate recipe: the default-FAIL contract.
+
+An agent can't mark a result "passing" until it has actually *looked* — opened a
+screenshot or console log with the Read tool. A ``PreToolUse`` hook denies any
+write to the results file unless evidence was read this session; reading
+evidence "unlocks" the next write, and each gated write consumes it so the next
+change needs fresh proof. This is the structural answer to "premature victory"
+(one of the three long-running-agent failure modes).
+
+State (the JSON-backed session dict) is the mechanism on purpose: each hook fires
+as a separate process in Claude Code, so the read tracked in one invocation must
+be visible to the write gate in another — in-memory wouldn't survive.
+
+Engine for ``fasthooks add evidence-gate``. Ported from Anthropic's
+cwc-long-running-agents (Apache-2.0) ``track-read.sh`` + ``verify-gate.sh``.
+This is a teaching example, not a security boundary — see the known gaps below.
+"""
+from __future__ import annotations
+
+from fasthooks.blueprint import Blueprint
+from fasthooks.depends import State
+from fasthooks.events.tools import ToolEvent
+from fasthooks.responses import HookResponse, deny
+
+DEFAULT_RESULTS_FILE = "test-results.json"
+
+# What counts as "the agent actually looked" (cwc track-read.sh patterns).
+_EVIDENCE_MARKERS = ("screenshots/", "-console.txt", "-result.txt", ".png")
+_STATE_KEY = "evidence_gate.reads"
+
+
+def _is_evidence(path: str) -> bool:
+    return any(marker in path for marker in _EVIDENCE_MARKERS)
+
+
+def _is_results(path: str, results_file: str) -> bool:
+    # Anchor on a path separator so e.g. vitest-results.json doesn't match.
+    return path == results_file or path.endswith("/" + results_file)
+
+
+def evidence_gate(results_file: str = DEFAULT_RESULTS_FILE) -> Blueprint:
+    """Deny writes to ``results_file`` unless evidence was Read this session.
+
+    Point ``results_file`` at your project's results file (e.g.
+    ``test-results.json``). The agent must open a screenshot / console log with
+    the Read tool before it can mark anything passing there.
+
+    Faithful to the cwc reference (a teaching example, not a security boundary).
+    Shared known gaps: only Write/Edit are gated — a Bash ``sed``/``jq`` can
+    rewrite the file unchecked; the evidence match is substring-based; and any
+    evidence read unlocks any results write, not the corresponding row.
+    """
+    bp = Blueprint(f"evidence_gate[{results_file}]")
+
+    @bp.pre_tool("Read")
+    def track_read(event: ToolEvent, state: State) -> None:
+        path = event.tool_input.get("file_path", "")
+        if _is_evidence(path):
+            state.setdefault(_STATE_KEY, []).append(path)
+            state.save()
+
+    @bp.pre_tool("Write", "Edit")
+    def gate_results(event: ToolEvent, state: State) -> HookResponse | None:
+        path = event.tool_input.get("file_path", "")
+        if not _is_results(path, results_file):
+            return None
+        if not state.get(_STATE_KEY):
+            return deny(
+                f"Cannot modify {results_file}: no screenshot or console-log "
+                "evidence has been Read this session. Open the evidence file "
+                "with the Read tool first, then retry."
+            )
+        state[_STATE_KEY] = []  # consume — the next change needs fresh proof
+        state.save()
+        return None
+
+    return bp

--- a/src/fasthooks/recipes/evidence_gate.py
+++ b/src/fasthooks/recipes/evidence_gate.py
@@ -17,8 +17,11 @@ This is a teaching example, not a security boundary — see the known gaps below
 """
 from __future__ import annotations
 
+import sys
+
 from fasthooks.blueprint import Blueprint
 from fasthooks.depends import State
+from fasthooks.depends.state import NullState
 from fasthooks.events.tools import ToolEvent
 from fasthooks.responses import HookResponse, deny
 
@@ -63,6 +66,18 @@ def evidence_gate(results_file: str = DEFAULT_RESULTS_FILE) -> Blueprint:
     def gate_results(event: ToolEvent, state: State) -> HookResponse | None:
         path = event.tool_input.get("file_path", "")
         if not _is_results(path, results_file):
+            return None
+        if isinstance(state, NullState):
+            # No persistent State -> the evidence read can't survive to this
+            # separate hook process, so enforcing here would deny *forever*.
+            # Fail open and tell the developer to wire up persistence, rather
+            # than deadlock the advertised workflow.
+            print(
+                "[fasthooks] evidence_gate is inert: it needs "
+                "HookApp(state_dir=...) to persist evidence reads across hook "
+                "processes. Allowing the write.",
+                file=sys.stderr,
+            )
             return None
         if not state.get(_STATE_KEY):
             return deny(

--- a/src/fasthooks/recipes/heartbeat.py
+++ b/src/fasthooks/recipes/heartbeat.py
@@ -1,0 +1,56 @@
+"""Heartbeat recipe: write a "still alive" marker on every tool call.
+
+A watchdog (or the dashboard's LAST CHECK-IN panel) reads the marker to detect
+stalls: if ``now - ts`` exceeds your threshold, the agent has gone quiet. The
+*timeout → move to the next feature* decision is the loop's, not the hook's —
+this primitive only emits the signal.
+
+Passive by design: it never affects the tool decision and never raises (a
+heartbeat that could block or crash a hook would be worse than no heartbeat).
+
+Note: if you run the SQLiteObserver / studio, every hook event is already
+timestamped there — this file is the no-DB, ``watch``/tail-from-a-terminal
+alternative (``watch -n 2 cat .claude/heartbeat.json``).
+
+Engine for ``fasthooks add heartbeat``.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from fasthooks.blueprint import Blueprint
+from fasthooks.events.tools import ToolEvent
+
+DEFAULT_PATH = ".claude/heartbeat.json"
+
+
+def heartbeat(path: str = DEFAULT_PATH) -> Blueprint:
+    """Overwrite ``path`` (relative to the event cwd) with the latest activity.
+
+    The marker is ``{ts, tool, session_id}`` rewritten on every tool call, so a
+    watchdog can read the freshest ``ts`` to tell whether the agent is still
+    making progress.
+    """
+    bp = Blueprint(f"heartbeat[{path}]")
+
+    @bp.pre_tool()  # catch-all: every tool is a beat
+    def beat(event: ToolEvent) -> None:
+        marker = Path(event.cwd) / path
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.write_text(
+                json.dumps(
+                    {
+                        "ts": time.time(),
+                        "tool": event.tool_name,
+                        "session_id": event.session_id,
+                    }
+                )
+            )
+        except OSError:
+            pass  # a heartbeat must never break the hook it rides on
+        return None  # passive: never affects the decision
+
+    return bp

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -5,6 +5,7 @@ from rich.console import Console
 
 from fasthooks import HookApp
 from fasthooks.recipes import (
+    evaluator_gate,
     evidence_gate,
     include_recipes,
     kill_switch,
@@ -85,6 +86,43 @@ def test_evidence_gate_requires_evidence_read_before_results_write(tmp_path):
     assert c.send(MockEvent.write("test-results.json", "{}")).decision == "deny"
 
 
+def _evaluator_stub(tmp_path, verdict_body: str) -> str:
+    script = tmp_path / "ev.sh"
+    script.write_text(f"#!/usr/bin/env bash\n{verdict_body}\n")
+    script.chmod(0o755)
+    return str(script)
+
+
+def test_evaluator_gate_blocks_stop_on_non_pass(tmp_path):
+    app = HookApp()
+    cmd = _evaluator_stub(tmp_path, 'echo NEEDS_WORK; echo "missing screenshot"')
+    app.include(evaluator_gate(command=cmd))
+    r = TestClient(app).send(MockEvent.stop(cwd=str(tmp_path)))
+    assert r is not None and r.decision == "block"
+    assert "NEEDS_WORK" in r.reason and "missing screenshot" in r.reason
+
+
+def test_evaluator_gate_allows_stop_on_pass(tmp_path):
+    app = HookApp()
+    app.include(evaluator_gate(command=_evaluator_stub(tmp_path, "echo PASS")))
+    assert TestClient(app).send(MockEvent.stop(cwd=str(tmp_path))) is None
+
+
+def test_evaluator_gate_fails_open_when_evaluator_missing(tmp_path):
+    """A missing/broken evaluator must never wedge the session — allow the stop."""
+    app = HookApp()
+    app.include(evaluator_gate(command="fasthooks-no-such-binary-xyz"))
+    assert TestClient(app).send(MockEvent.stop(cwd=str(tmp_path))) is None
+
+
+def test_evaluator_gate_recursion_guard(tmp_path, monkeypatch):
+    """An evaluation must not trigger another: the sentinel env short-circuits."""
+    monkeypatch.setenv("FASTHOOKS_EVALUATOR_GATE_ACTIVE", "1")
+    app = HookApp()
+    app.include(evaluator_gate(command=_evaluator_stub(tmp_path, "echo NEEDS_WORK")))
+    assert TestClient(app).send(MockEvent.stop(cwd=str(tmp_path))) is None
+
+
 # ── Scaffolding ──────────────────────────────────────────────────────────────
 
 
@@ -94,6 +132,8 @@ def test_scaffold_default_is_derived_from_engine(tmp_path):
     assert 'kill_switch(sentinel="AGENT_STOP")' in scaffold_for("kill-switch")
     assert 'steer(sentinel="STEER.md")' in scaffold_for("steer")
     assert 'evidence_gate(results_file="test-results.json")' in scaffold_for("evidence-gate")
+    # evaluator-gate's default embeds a quoted prompt — the scaffold must stay valid Python.
+    compile(scaffold_for("evaluator-gate"), "<scaffold>", "exec")
 
 
 # ── Discovery ────────────────────────────────────────────────────────────────

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 from rich.console import Console
 
 from fasthooks import HookApp
-from fasthooks.recipes import include_recipes, kill_switch, scaffold_for, steer
-from fasthooks.testing import TestClient
+from fasthooks.recipes import (
+    evidence_gate,
+    include_recipes,
+    kill_switch,
+    scaffold_for,
+    steer,
+)
+from fasthooks.testing import MockEvent, TestClient
 
 
 def _pre_tool(cwd: str) -> dict:
@@ -50,13 +56,44 @@ def test_steer_injects_then_clears(tmp_path):
     assert not steer_file.exists()  # delivered exactly once
 
 
+def test_evidence_gate_requires_evidence_read_before_results_write(tmp_path):
+    """Default-FAIL: the results file can't be written until evidence is Read.
+
+    Needs a real state_dir — the read tracked in one hook invocation must be
+    visible to the write gate in the next (separate process in production).
+    """
+    app = HookApp(state_dir=str(tmp_path))
+    app.include(evidence_gate(results_file="test-results.json"))
+    c = TestClient(app)
+
+    # 1. write without evidence -> denied
+    r = c.send(MockEvent.write("test-results.json", "{}"))
+    assert r is not None and r.decision == "deny"
+
+    # 2. read a screenshot (evidence) -> the next write is allowed
+    c.send(MockEvent.read("screenshots/feature-1.png"))
+    assert c.send(MockEvent.write("test-results.json", "{}")) is None
+
+    # 3. evidence consumed -> the following write is denied again
+    assert c.send(MockEvent.write("test-results.json", "{}")).decision == "deny"
+
+    # 4. a non-results write is never gated
+    assert c.send(MockEvent.write("src/app.py", "x = 1")) is None
+
+    # 5. a non-evidence read (no screenshot/console marker) does not unlock
+    c.send(MockEvent.read("README.md"))
+    assert c.send(MockEvent.write("test-results.json", "{}")).decision == "deny"
+
+
 # ── Scaffolding ──────────────────────────────────────────────────────────────
 
 
 def test_scaffold_default_is_derived_from_engine(tmp_path):
-    # Guards against the scaffold's default drifting from the factory default.
+    # Guards against the scaffold's default (and knob name) drifting from the
+    # factory signature.
     assert 'kill_switch(sentinel="AGENT_STOP")' in scaffold_for("kill-switch")
     assert 'steer(sentinel="STEER.md")' in scaffold_for("steer")
+    assert 'evidence_gate(results_file="test-results.json")' in scaffold_for("evidence-gate")
 
 
 # ── Discovery ────────────────────────────────────────────────────────────────

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,12 +1,15 @@
 """Recipes: engine behavior, scaffolding, and fail-open discovery."""
 from __future__ import annotations
 
+import json
+
 from rich.console import Console
 
 from fasthooks import HookApp
 from fasthooks.recipes import (
     evaluator_gate,
     evidence_gate,
+    heartbeat,
     include_recipes,
     kill_switch,
     scaffold_for,
@@ -142,6 +145,18 @@ def test_evidence_gate_fails_open_without_persistent_state(tmp_path, capsys):
     # No evidence read; with real State this would deny. Here it must allow.
     assert c.send(MockEvent.write("test-results.json", "{}")) is None
     assert "inert" in capsys.readouterr().err
+
+
+def test_heartbeat_writes_marker_and_is_passive(tmp_path):
+    app = HookApp()
+    app.include(heartbeat(path="hb.json"))
+    r = TestClient(app).send(MockEvent.bash("ls", cwd=str(tmp_path)))
+    assert r is None  # passive — never affects the decision
+
+    marker = tmp_path / "hb.json"
+    assert marker.exists()
+    data = json.loads(marker.read_text())
+    assert data["tool"] == "Bash" and data["ts"] > 0
 
 
 # ── Scaffolding ──────────────────────────────────────────────────────────────

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -123,6 +123,27 @@ def test_evaluator_gate_recursion_guard(tmp_path, monkeypatch):
     assert TestClient(app).send(MockEvent.stop(cwd=str(tmp_path))) is None
 
 
+def test_evaluator_gate_fails_open_on_nonzero_exit(tmp_path):
+    """A non-zero exit (e.g. unauthenticated `claude`) is an infra failure, not a
+    NEEDS_WORK verdict — fail open, don't wedge Stop with a bogus block."""
+    app = HookApp()
+    # exits 1 with no stdout — like an auth/config error
+    cmd = _evaluator_stub(tmp_path, 'echo "auth error" >&2; exit 1')
+    app.include(evaluator_gate(command=cmd))
+    assert TestClient(app).send(MockEvent.stop(cwd=str(tmp_path))) is None
+
+
+def test_evidence_gate_fails_open_without_persistent_state(tmp_path, capsys):
+    """With the default HookApp() (NullState), the gate can't persist evidence
+    across processes — so it must fail OPEN (allow + warn), not deadlock."""
+    app = HookApp()  # no state_dir -> NullState
+    app.include(evidence_gate(results_file="test-results.json"))
+    c = TestClient(app)
+    # No evidence read; with real State this would deny. Here it must allow.
+    assert c.send(MockEvent.write("test-results.json", "{}")) is None
+    assert "inert" in capsys.readouterr().err
+
+
 # ── Scaffolding ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Ships the long-running-agent harness as **composable recipes** (the "primitives as a pipeline, not a god-class strategy" direction), matching Anthropic's official [`cwc-long-running-agents`](https://github.com/anthropics/cwc-long-running-agents) reference. Three new recipes complete the set — `kill-switch`/`steer` already shipped:

| cwc / dashboard primitive | recipe |
|---|---|
| PROOF IT LOOKED · **HARD GATE** | **`evidence-gate`** — default-FAIL: deny marking a result passing unless evidence (screenshot/console-log) was Read this session |
| SECOND OPINION · **EVALUATOR** | **`evaluator-gate`** — on Stop, run a fresh-context evaluator and block unless it returns PASS |
| LAST CHECK-IN · **WATCHDOG** | **`heartbeat`** — write a `{ts, tool, session_id}` marker each tool call for stall detection |

Compose them: `app.include(evidence_gate(...))` etc., or drop configs and `include_recipes()`.

## Safety: both gates degrade *open* on misconfiguration
Codex review (two passes) caught two real failure modes, both fixed with regression tests:
- **evidence-gate** would *deadlock* under the default `HookApp()` (`NullState`, no persistence — the Read never survives to the separate Write process). Now detects `NullState` → **fails open + warns** to configure `state_dir`.
- **evaluator-gate** non-zero exit wasn't fail-open (`subprocess.run` doesn't raise without `check=True`) — an unauthenticated `claude` exiting 1 became a bogus `NEEDS_WORK` block. Now `returncode != 0` → **fails open** with a stderr diagnostic.

A setup mistake warns and allows; it never wedges the workflow.

## Also
- Generalized `scaffold_for` to read each recipe's own knob (was hardcoded `sentinel`).
- `HARNESS-PLAN.md` — living plan/scratchpad (references, primitive inventory, decisions log, phased plan). Tracks #15.

## Verification
**705 tests pass**, ruff + mypy clean. Every recipe verified end-to-end (the gates' allow/deny/fail-open paths, the heartbeat marker, the recursion sentinel).

## Scope / follow-ups (in the plan)
The **loop** (build→evaluate→rebuild, timeout→next) and a **dashboard** stay *outside* fasthooks. Next: decompose/deprecate `LongRunningStrategy` in favor of `include_recipes` (P4), and a separate dashboard showcase repo (P5).