### PR TITLE
feat(recipes): commit_on_stop + composable long-running harness example (#15)

### DIFF
--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -86,8 +86,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
       in the loop. Overlaps with the observer stream (which already timestamps
       every event) — the file is the no-DB, tail-from-a-terminal alternative.
       `fasthooks add heartbeat`.
-- [ ] **P4 · decompose `LongRunningStrategy`** → a thin bundle of the recipes
-      above (or deprecate it in favor of `include_recipes(...)`). DX-first.
+- [x] **P4 · deprecate `LongRunningStrategy`** — ✅ done (2026-06-02). Extracted
+      the missing reusable mechanism (`commit_on_stop`, cwc-style auto-commit
+      backstop) as the 6th recipe, then deprecated the strategy (DeprecationWarning
+      + docstring + docs banner) pointing at `include_recipes`. Its opinionated
+      session-routing/handoff *prompt* content is intentionally dropped — roll
+      your own `@app.on_session_start` context. Kept (not deleted) for a
+      migration window. `fasthooks add commit-on-stop`.
 - [ ] **P5 · dashboard showcase (separate repo)** — consumes fasthooks'
       `SQLiteObserver`/studio event stream + on-disk artifacts (PROGRESS, git
       log, tests.json, screenshots). fasthooks = substrate; dashboard = app.
@@ -136,6 +141,11 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
   knobs along the way.
 - 2026-06-02 — P2 `evaluator-gate`: ship with 3 guards (recursion sentinel,
   timeout, fail-open). Plumbing + guards verified with a stub evaluator.
+- 2026-06-02 — P4: extract `commit_on_stop` (cwc auto-commit backstop) as a
+  recipe, then **deprecate `LongRunningStrategy`** (warn, keep for a migration
+  window) — recipes cover the mechanisms; the strategy's prompt/routing content
+  is dropped as the opinionated god-class part. Resolves the P4 open question
+  (deprecate, not thin-bundle).
 - 2026-06-02 — Codex review (2 passes) caught two real failure modes, both fixed:
   (a) evidence-gate would *deadlock* under the default `HookApp()` (NullState,
   no persistence) — now detects NullState and **fails open + warns** (and the

--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -146,6 +146,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
   window) — recipes cover the mechanisms; the strategy's prompt/routing content
   is dropped as the opinionated god-class part. Resolves the P4 open question
   (deprecate, not thin-bundle).
+- 2026-06-02 — P4 Codex review: standard pass flagged `commit_on_stop` +
+  `evaluator_gate` ordering (commit fires before a later gate blocks). Resolved:
+  this is the cwc primitive's intended *commit-on-every-stop* behavior (frequent
+  WIP backstop), so kept it — but renamed the message `session checkpoint` ->
+  `wip checkpoint` (was misleading), documented the interaction, and pinned both
+  orders in a test (include AFTER gates to commit-only-on-allowed-stop, since
+  dispatch short-circuits on first block). Adversarial pass: approve.
 - 2026-06-02 — Codex review (2 passes) caught two real failure modes, both fixed:
   (a) evidence-gate would *deadlock* under the default `HookApp()` (NullState,
   no persistence) — now detects NullState and **fails open + warns** (and the

--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -146,6 +146,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
   window) — recipes cover the mechanisms; the strategy's prompt/routing content
   is dropped as the opinionated god-class part. Resolves the P4 open question
   (deprecate, not thin-bundle).
+- 2026-06-02 — Deprecation needs a *replacement*, not just a warning: added
+  `examples/long_running_harness.py` — the full harness composed from the 6
+  recipes (with `state_dir`, gate-then-commit ordering, and the session-routing
+  context as a plain `on_session_start` handler). Deprecation message + docs now
+  point at it. Building it surfaced a real `fasthooks test` gap (SessionStart/
+  SessionEnd/PreCompact/Notification envelopes missed their required fields) —
+  fixed + tested.
 - 2026-06-02 — P4 Codex review: standard pass flagged `commit_on_stop` +
   `evaluator_gate` ordering (commit fires before a later gate blocks). Resolved:
   this is the cwc primitive's intended *commit-on-every-stop* behavior (frequent

--- a/HARNESS-PLAN.md
+++ b/HARNESS-PLAN.md
@@ -86,13 +86,13 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
       in the loop. Overlaps with the observer stream (which already timestamps
       every event) — the file is the no-DB, tail-from-a-terminal alternative.
       `fasthooks add heartbeat`.
-- [x] **P4 · deprecate `LongRunningStrategy`** — ✅ done (2026-06-02). Extracted
-      the missing reusable mechanism (`commit_on_stop`, cwc-style auto-commit
-      backstop) as the 6th recipe, then deprecated the strategy (DeprecationWarning
-      + docstring + docs banner) pointing at `include_recipes`. Its opinionated
-      session-routing/handoff *prompt* content is intentionally dropped — roll
-      your own `@app.on_session_start` context. Kept (not deleted) for a
-      migration window. `fasthooks add commit-on-stop`.
+- [x] **P4 · composable harness > `LongRunningStrategy`** — ✅ done (2026-06-02).
+      Extracted the missing reusable mechanism (`commit_on_stop`, cwc-style
+      auto-commit backstop) as the 6th recipe, and added
+      `examples/long_running_harness.py` showing the recipe-composed harness.
+      `LongRunningStrategy` stays as-is with a plain doc/docstring note pointing
+      at the recipe approach. **No deprecation ceremony** — no users, greenfield;
+      just state the current preferred shape. `fasthooks add commit-on-stop`.
 - [ ] **P5 · dashboard showcase (separate repo)** — consumes fasthooks'
       `SQLiteObserver`/studio event stream + on-disk artifacts (PROGRESS, git
       log, tests.json, screenshots). fasthooks = substrate; dashboard = app.
@@ -142,10 +142,10 @@ Anthropic's official reference design and fasthooks' own Blueprint/recipe model.
 - 2026-06-02 — P2 `evaluator-gate`: ship with 3 guards (recursion sentinel,
   timeout, fail-open). Plumbing + guards verified with a stub evaluator.
 - 2026-06-02 — P4: extract `commit_on_stop` (cwc auto-commit backstop) as a
-  recipe, then **deprecate `LongRunningStrategy`** (warn, keep for a migration
-  window) — recipes cover the mechanisms; the strategy's prompt/routing content
-  is dropped as the opinionated god-class part. Resolves the P4 open question
-  (deprecate, not thin-bundle).
+  recipe + add `examples/long_running_harness.py` (recipe-composed harness).
+  **Decided NOT to deprecate** `LongRunningStrategy` — no users, greenfield, so a
+  DeprecationWarning + migration ceremony is fluff. Just state the current
+  preferred shape (recipes) with a plain doc note; leave the strategy as-is.
 - 2026-06-02 — Deprecation needs a *replacement*, not just a warning: added
   `examples/long_running_harness.py` — the full harness composed from the 6
   recipes (with `state_dir`, gate-then-commit ordering, and the session-routing

--- a/docs/strategies/long-running.md
+++ b/docs/strategies/long-running.md
@@ -7,7 +7,9 @@
     `include_recipes` (or `app.include(...)`). This class also bundled
     opinionated *prompt* content (initializer/coding session routing,
     progress-file handoff); that part is intentionally not ported — write your
-    own `@app.on_session_start` context if you want it. See `fasthooks add`.
+    own `@app.on_session_start` context if you want it. See
+    [`examples/long_running_harness.py`](https://github.com/oneryalcin/fasthooks/blob/main/examples/long_running_harness.py)
+    for the full recipe-composed replacement.
 
 The `LongRunningStrategy` implements Anthropic's two-agent pattern for autonomous agents that work across multiple context windows. It prevents the two common failure modes of long-running agents: **one-shotting** (trying to do everything at once) and **premature victory** (declaring done too early).
 

--- a/docs/strategies/long-running.md
+++ b/docs/strategies/long-running.md
@@ -1,15 +1,11 @@
 # Long-Running Agent Strategy
 
-!!! warning "Deprecated — compose the harness recipes instead"
-    `LongRunningStrategy` is deprecated. The reusable mechanisms now ship as
-    standalone, testable **recipes** you pipe together — `kill_switch`, `steer`,
-    `evidence_gate`, `evaluator_gate`, `heartbeat`, `commit_on_stop` — via
-    `include_recipes` (or `app.include(...)`). This class also bundled
-    opinionated *prompt* content (initializer/coding session routing,
-    progress-file handoff); that part is intentionally not ported — write your
-    own `@app.on_session_start` context if you want it. See
+!!! note "Prefer composing recipes"
+    The mechanisms here also ship as standalone, composable **recipes**
+    (`kill_switch`, `steer`, `evidence_gate`, `evaluator_gate`, `heartbeat`,
+    `commit_on_stop`). See
     [`examples/long_running_harness.py`](https://github.com/oneryalcin/fasthooks/blob/main/examples/long_running_harness.py)
-    for the full recipe-composed replacement.
+    for the recipe-based way to assemble a harness — most projects will prefer it.
 
 The `LongRunningStrategy` implements Anthropic's two-agent pattern for autonomous agents that work across multiple context windows. It prevents the two common failure modes of long-running agents: **one-shotting** (trying to do everything at once) and **premature victory** (declaring done too early).
 

--- a/docs/strategies/long-running.md
+++ b/docs/strategies/long-running.md
@@ -1,5 +1,14 @@
 # Long-Running Agent Strategy
 
+!!! warning "Deprecated — compose the harness recipes instead"
+    `LongRunningStrategy` is deprecated. The reusable mechanisms now ship as
+    standalone, testable **recipes** you pipe together — `kill_switch`, `steer`,
+    `evidence_gate`, `evaluator_gate`, `heartbeat`, `commit_on_stop` — via
+    `include_recipes` (or `app.include(...)`). This class also bundled
+    opinionated *prompt* content (initializer/coding session routing,
+    progress-file handoff); that part is intentionally not ported — write your
+    own `@app.on_session_start` context if you want it. See `fasthooks add`.
+
 The `LongRunningStrategy` implements Anthropic's two-agent pattern for autonomous agents that work across multiple context windows. It prevents the two common failure modes of long-running agents: **one-shotting** (trying to do everything at once) and **premature victory** (declaring done too early).
 
 > **Live Example**: See a full expense tracker app built autonomously using this strategy:

--- a/examples/long_running_harness.py
+++ b/examples/long_running_harness.py
@@ -1,0 +1,82 @@
+"""Long-running agent harness, assembled from fasthooks recipes.
+
+The composable replacement for the deprecated ``LongRunningStrategy``: each
+mechanism is a small, tested recipe you pipe together, plus your *own*
+session-start context (the part that was opinionated prompt content baked into
+the old strategy). This is the "primitives as a pipeline, not a god-class"
+shape — keep, drop, or swap any line.
+
+Smoke-test the hooks without Claude Code (see `fasthooks test`):
+
+    # the session-routing context (initializer vs coding)
+    fasthooks test examples/long_running_harness.py -e SessionStart
+
+    # the evidence gate denies marking results passing with no evidence Read
+    fasthooks test examples/long_running_harness.py -e PreToolUse:Write \\
+        -i '{"file_path": "test-results.json"}'
+
+(`-e Stop` runs the real `evaluator_gate` command — i.e. spawns `claude` — so it
+only makes sense once you've wired up an evaluator agent.)
+"""
+from pathlib import Path
+
+from fasthooks import HookApp, context
+from fasthooks.recipes import (
+    commit_on_stop,
+    evaluator_gate,
+    evidence_gate,
+    heartbeat,
+    kill_switch,
+    steer,
+)
+
+# evidence_gate tracks Reads across separate hook processes, so it needs
+# PERSISTENT state — construct the app with a state_dir (without it the gate
+# fails open and warns rather than enforcing).
+app = HookApp(state_dir=".claude/state")
+
+# ── The harness pipeline ──────────────────────────────────────────────────────
+# Operator controls + the passive signal first; then the blocking gates; the
+# commit backstop LAST so a gate's block short-circuits before the checkpoint
+# (commit only when the stop is actually allowed).
+app.include(kill_switch())          # freeze the agent via an AGENT_STOP file
+app.include(steer())                # redirect mid-run via STEER.md
+app.include(heartbeat())            # stall-detection marker on every tool call
+app.include(evidence_gate(results_file="test-results.json"))  # default-FAIL contract
+app.include(
+    evaluator_gate(                 # fresh-context second opinion on Stop
+        command=(
+            "claude --agent evaluator -p 'Review the latest commit against its "
+            "spec. First line PASS or NEEDS_WORK, then findings.'"
+        ),
+    )
+)
+app.include(commit_on_stop())       # durability backstop (after the gate)
+
+# ── Your own session context (replaces the strategy's opinionated prompts) ────
+FEATURE_LIST = "feature_list.json"
+
+
+@app.on_session_start()
+def route(event):
+    """Initializer vs coding context — the bit that was prompt content before.
+
+    First run (no feature list) → set the project up. Later runs → make
+    incremental, verified progress. Adapt the wording to your project.
+    """
+    if not (Path(event.cwd) / FEATURE_LIST).exists():
+        return context(
+            "INITIALIZER: create feature_list.json (each feature "
+            '{"passes": false}), a claude-progress.txt handoff file, and '
+            "`git init` with a first commit. Then stop."
+        )
+    return context(
+        "CODING: read claude-progress.txt, pick the next failing feature, "
+        "implement it, verify it with a screenshot or console log (open it with "
+        "Read), then mark it passing in test-results.json and commit. Update "
+        "claude-progress.txt before you stop."
+    )
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/fasthooks/cli/commands/smoke.py
+++ b/src/fasthooks/cli/commands/smoke.py
@@ -57,6 +57,15 @@ def build_event(
         event["prompt"] = tool_input.get("prompt", "") if isinstance(tool_input, dict) else ""
     elif event_name in ("Stop", "SubagentStop"):
         event["stop_hook_active"] = False
+    elif event_name == "SessionStart":
+        event["source"] = "startup"  # startup | resume | clear | compact
+    elif event_name == "SessionEnd":
+        event["reason"] = "other"  # clear | logout | prompt_input_exit | other
+    elif event_name == "PreCompact":
+        event["trigger"] = "manual"  # manual | auto
+    elif event_name == "Notification":
+        event["message"] = ""
+        event["notification_type"] = "idle_prompt"
     return event
 
 

--- a/src/fasthooks/recipes/__init__.py
+++ b/src/fasthooks/recipes/__init__.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from fasthooks.recipes.commit_on_stop import commit_on_stop
 from fasthooks.recipes.evaluator_gate import evaluator_gate
 from fasthooks.recipes.evidence_gate import evidence_gate
 from fasthooks.recipes.heartbeat import heartbeat
@@ -36,6 +37,7 @@ __all__ = [
     "evidence_gate",
     "evaluator_gate",
     "heartbeat",
+    "commit_on_stop",
     "RECIPES",
     "scaffold_for",
     "include_recipes",
@@ -98,6 +100,15 @@ RECIPES: dict[str, RecipeSpec] = {
             "watchdog/dashboard can detect stalls. Passive (never blocks). If "
             "you run the SQLiteObserver/studio you already have timestamps "
             "there; this is the no-DB, tail-from-a-terminal alternative."
+        ),
+    ),
+    "commit-on-stop": RecipeSpec(
+        factory=commit_on_stop,
+        summary="Auto-commit tracked changes at session end (durability backstop).",
+        doc=(
+            "On Stop, `git commit -am '<message_prefix>: <timestamp>'` when there "
+            "are tracked changes. Passive backstop (never blocks, fails silent); "
+            "untracked files are left for the agent to `git add`."
         ),
     ),
 }

--- a/src/fasthooks/recipes/__init__.py
+++ b/src/fasthooks/recipes/__init__.py
@@ -104,11 +104,14 @@ RECIPES: dict[str, RecipeSpec] = {
     ),
     "commit-on-stop": RecipeSpec(
         factory=commit_on_stop,
-        summary="Auto-commit tracked changes at session end (durability backstop).",
+        summary="Auto-commit tracked changes on every Stop (durability backstop).",
         doc=(
             "On Stop, `git commit -am '<message_prefix>: <timestamp>'` when there "
             "are tracked changes. Passive backstop (never blocks, fails silent); "
-            "untracked files are left for the agent to `git add`."
+            "untracked files are left for the agent to `git add`. Fires on every "
+            "Stop (frequent WIP checkpoints). To commit only when the stop is "
+            "actually allowed, include this AFTER your blocking gates so a block "
+            "short-circuits it."
         ),
     ),
 }

--- a/src/fasthooks/recipes/commit_on_stop.py
+++ b/src/fasthooks/recipes/commit_on_stop.py
@@ -11,6 +11,16 @@ repo, nothing to commit, or the commit fails (no ``user.name``, a rejecting
 hook, ...), it silently does nothing — it's a backstop, not a gate. Check
 ``git log`` periodically when relying on it.
 
+**It commits on every Stop**, including ones a *later* Stop gate then blocks —
+that's intended (the dashboard's "committed every few minutes"): in an
+autonomous loop the stop fires each turn, so WIP is saved continuously. The
+commits are working checkpoints (hence the ``wip checkpoint`` message), not a
+claim the session ended. fasthooks short-circuits on the first blocking
+handler, so if you instead want to commit *only when the stop is actually
+allowed*, include this recipe **after** your blocking gates (e.g.
+``include_recipes(...)`` then ``app.include(commit_on_stop())``) — a gate's
+block will short-circuit before it runs.
+
 Engine for ``fasthooks add commit-on-stop``. Ported from Anthropic's
 cwc-long-running-agents (Apache-2.0) ``commit-on-stop.sh``.
 """
@@ -22,14 +32,16 @@ import time
 from fasthooks.blueprint import Blueprint
 from fasthooks.events.lifecycle import Stop
 
-DEFAULT_PREFIX = "session checkpoint"
+DEFAULT_PREFIX = "wip checkpoint"
 
 
 def commit_on_stop(message_prefix: str = DEFAULT_PREFIX) -> Blueprint:
     """Commit tracked changes on Stop with ``"<message_prefix>: <timestamp>"``.
 
     Only commits when there are tracked (staged or unstaged) changes; untracked
-    files are left alone. Always allows the stop.
+    files are left alone. Always allows the stop. Fires on *every* Stop (a
+    frequent WIP backstop) — see the module docstring for the interaction with
+    blocking Stop gates and how to commit-only-on-allowed-stop.
     """
     bp = Blueprint("commit_on_stop")
 

--- a/src/fasthooks/recipes/commit_on_stop.py
+++ b/src/fasthooks/recipes/commit_on_stop.py
@@ -1,0 +1,64 @@
+"""Commit-on-stop recipe: auto-commit tracked changes at session end.
+
+A backstop so work is durable across restarts even when the agent forgets to
+commit (the dashboard's "WORK SAVED · committed every few minutes"). Uses
+``git commit -am`` (tracked files only) on purpose — ephemeral artifacts
+(screenshots, logs, scratch) shouldn't land in history; the agent ``git add``s
+new source files itself.
+
+Passive by design: it never blocks the stop and never raises. If there's no git
+repo, nothing to commit, or the commit fails (no ``user.name``, a rejecting
+hook, ...), it silently does nothing — it's a backstop, not a gate. Check
+``git log`` periodically when relying on it.
+
+Engine for ``fasthooks add commit-on-stop``. Ported from Anthropic's
+cwc-long-running-agents (Apache-2.0) ``commit-on-stop.sh``.
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+
+from fasthooks.blueprint import Blueprint
+from fasthooks.events.lifecycle import Stop
+
+DEFAULT_PREFIX = "session checkpoint"
+
+
+def commit_on_stop(message_prefix: str = DEFAULT_PREFIX) -> Blueprint:
+    """Commit tracked changes on Stop with ``"<message_prefix>: <timestamp>"``.
+
+    Only commits when there are tracked (staged or unstaged) changes; untracked
+    files are left alone. Always allows the stop.
+    """
+    bp = Blueprint("commit_on_stop")
+
+    @bp.on_stop()
+    def commit(event: Stop) -> None:
+        cwd = event.cwd or None
+
+        def git(*args: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                ["git", *args],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        try:
+            if git("rev-parse", "--git-dir").returncode != 0:
+                return None  # not a git repo
+            # Tracked changes only (unstaged or staged) — mirrors cwc's
+            # `! git diff --quiet || ! git diff --cached --quiet`.
+            unstaged = git("diff", "--quiet").returncode != 0
+            staged = git("diff", "--cached", "--quiet").returncode != 0
+            if not (unstaged or staged):
+                return None  # nothing tracked to commit
+            stamp = time.strftime("%Y-%m-%d %H:%M")
+            git("commit", "-am", f"{message_prefix}: {stamp}")
+        except (OSError, subprocess.SubprocessError):
+            pass  # backstop: a failed commit must never wedge the stop
+        return None  # passive: always allows the stop
+
+    return bp

--- a/src/fasthooks/strategies/long_running.py
+++ b/src/fasthooks/strategies/long_running.py
@@ -245,7 +245,7 @@ class LongRunningStrategy(Strategy):
         opinionated *prompt* content (initializer/coding session routing,
         progress-file handoff) — that part is intentionally not ported; write
         your own ``@app.on_session_start`` context if you want it. See
-        ``fasthooks add <recipe>`` and HARNESS-PLAN.md.
+        ``examples/long_running_harness.py`` for the full composed replacement.
 
     Implements the two-agent pattern:
     - Initializer: First run sets up feature_list.json, init.sh, git
@@ -294,7 +294,8 @@ class LongRunningStrategy(Strategy):
             "(kill_switch, steer, evidence_gate, evaluator_gate, heartbeat, "
             "commit_on_stop) via include_recipes instead. Its session-routing "
             "prompt content is not ported — write your own on_session_start "
-            "context. See HARNESS-PLAN.md.",
+            "context. See examples/long_running_harness.py for the full "
+            "recipe-composed replacement.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/fasthooks/strategies/long_running.py
+++ b/src/fasthooks/strategies/long_running.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import warnings
 from pathlib import Path
 from typing import Any, Literal
 
@@ -234,22 +233,17 @@ Before context fills up:
 
 
 class LongRunningStrategy(Strategy):
-    """Harness for long-running autonomous agents.
-
-    .. deprecated::
-        Prefer composing the harness **recipes** over this monolith. The
-        reusable mechanisms now ship as standalone, testable recipes you pipe
-        together with ``include_recipes`` (or ``app.include(...)``):
-        ``kill_switch``, ``steer``, ``evidence_gate``, ``evaluator_gate``,
-        ``heartbeat``, ``commit_on_stop``. This class additionally bundled
-        opinionated *prompt* content (initializer/coding session routing,
-        progress-file handoff) — that part is intentionally not ported; write
-        your own ``@app.on_session_start`` context if you want it. See
-        ``examples/long_running_harness.py`` for the full composed replacement.
+    """Harness for long-running autonomous agents (bundled form).
 
     Implements the two-agent pattern:
     - Initializer: First run sets up feature_list.json, init.sh, git
     - Coding: Subsequent runs make incremental progress
+
+    The reusable mechanisms here also ship as standalone, composable **recipes**
+    (``kill_switch``, ``steer``, ``evidence_gate``, ``evaluator_gate``,
+    ``heartbeat``, ``commit_on_stop``) — see
+    ``examples/long_running_harness.py`` for the recipe-based way to assemble a
+    harness, which most projects will prefer.
     """
 
     class Meta:
@@ -289,16 +283,6 @@ class LongRunningStrategy(Strategy):
         exclude_paths: list[str] | None = None,
         **config: Any,
     ):
-        warnings.warn(
-            "LongRunningStrategy is deprecated; compose the harness recipes "
-            "(kill_switch, steer, evidence_gate, evaluator_gate, heartbeat, "
-            "commit_on_stop) via include_recipes instead. Its session-routing "
-            "prompt content is not ported — write your own on_session_start "
-            "context. See examples/long_running_harness.py for the full "
-            "recipe-composed replacement.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**config)
         self.feature_list = feature_list
         self.progress_file = progress_file

--- a/src/fasthooks/strategies/long_running.py
+++ b/src/fasthooks/strategies/long_running.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import warnings
 from pathlib import Path
 from typing import Any, Literal
 
@@ -235,17 +236,20 @@ Before context fills up:
 class LongRunningStrategy(Strategy):
     """Harness for long-running autonomous agents.
 
+    .. deprecated::
+        Prefer composing the harness **recipes** over this monolith. The
+        reusable mechanisms now ship as standalone, testable recipes you pipe
+        together with ``include_recipes`` (or ``app.include(...)``):
+        ``kill_switch``, ``steer``, ``evidence_gate``, ``evaluator_gate``,
+        ``heartbeat``, ``commit_on_stop``. This class additionally bundled
+        opinionated *prompt* content (initializer/coding session routing,
+        progress-file handoff) — that part is intentionally not ported; write
+        your own ``@app.on_session_start`` context if you want it. See
+        ``fasthooks add <recipe>`` and HARNESS-PLAN.md.
+
     Implements the two-agent pattern:
     - Initializer: First run sets up feature_list.json, init.sh, git
     - Coding: Subsequent runs make incremental progress
-
-    Example:
-        strategy = LongRunningStrategy(
-            feature_list="feature_list.json",
-            progress_file="claude-progress.txt",
-            enforce_commits=True,
-        )
-        app.include(strategy.get_blueprint())
     """
 
     class Meta:
@@ -285,6 +289,15 @@ class LongRunningStrategy(Strategy):
         exclude_paths: list[str] | None = None,
         **config: Any,
     ):
+        warnings.warn(
+            "LongRunningStrategy is deprecated; compose the harness recipes "
+            "(kill_switch, steer, evidence_gate, evaluator_gate, heartbeat, "
+            "commit_on_stop) via include_recipes instead. Its session-routing "
+            "prompt content is not ported — write your own on_session_start "
+            "context. See HARNESS-PLAN.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(**config)
         self.feature_list = feature_list
         self.progress_file = progress_file

--- a/tests/strategies/test_long_running.py
+++ b/tests/strategies/test_long_running.py
@@ -10,12 +10,6 @@ from fasthooks.strategies import LongRunningStrategy
 from fasthooks.testing import StrategyTestClient
 
 
-def test_long_running_strategy_is_deprecated():
-    """Construction warns; compose the harness recipes via include_recipes instead."""
-    with pytest.warns(DeprecationWarning, match="include_recipes"):
-        LongRunningStrategy()
-
-
 def get_response_text(response: Any) -> str:
     """Extract text from response (handles ContextResponse and HookResponse)."""
     if response is None:

--- a/tests/strategies/test_long_running.py
+++ b/tests/strategies/test_long_running.py
@@ -10,6 +10,12 @@ from fasthooks.strategies import LongRunningStrategy
 from fasthooks.testing import StrategyTestClient
 
 
+def test_long_running_strategy_is_deprecated():
+    """Construction warns; compose the harness recipes via include_recipes instead."""
+    with pytest.warns(DeprecationWarning, match="include_recipes"):
+        LongRunningStrategy()
+
+
 def get_response_text(response: Any) -> str:
     """Extract text from response (handles ContextResponse and HookResponse)."""
     if response is None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -77,6 +77,20 @@ def _write(tmp_path: Path, name: str, body: str) -> Path:
     return p
 
 
+def test_envelope_populates_lifecycle_required_fields():
+    """Lifecycle events have required fields the generic envelope must supply,
+    or `fasthooks test -e SessionStart` (etc.) builds an invalid event."""
+    required = {
+        "SessionStart": "source",
+        "SessionEnd": "reason",
+        "PreCompact": "trigger",
+        "Notification": "notification_type",
+    }
+    for event_name, field in required.items():
+        env = build_event(event_name, None, {}, cwd="/w", transcript_path="/t.jsonl")
+        assert field in env, f"{event_name} envelope missing required {field!r}"
+
+
 def test_envelope_matches_mockevent():
     """Drift guard: the CLI envelope must carry every field MockEvent emits.
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -183,7 +183,7 @@ def test_commit_on_stop_commits_tracked_changes(tmp_path):
     (tmp_path / "a.txt").write_text("v2")
     assert c.send(MockEvent.stop(cwd=str(tmp_path))) is None
     log = git("log", "--oneline").stdout.strip().splitlines()
-    assert len(log) == 2 and "session checkpoint" in log[0]
+    assert len(log) == 2 and "wip checkpoint" in log[0]
 
     # clean -> no new commit
     c.send(MockEvent.stop(cwd=str(tmp_path)))
@@ -201,6 +201,43 @@ def test_commit_on_stop_silent_outside_git(tmp_path):
     app = HookApp()
     app.include(commit_on_stop())
     assert TestClient(app).send(MockEvent.stop(cwd=str(tmp_path))) is None
+
+
+def test_commit_on_stop_ordering_vs_blocking_gate(tmp_path):
+    """Composition with a blocking Stop gate is order-sensitive (documented).
+
+    Included BEFORE a gate: it commits, then the gate blocks (frequent WIP
+    checkpoint — fires on every stop). Included AFTER: the gate's block
+    short-circuits and it never commits (commit-only-on-allowed-stop)."""
+    from fasthooks import Blueprint, block
+
+    def blocker():
+        bp = Blueprint("blocker")
+
+        @bp.on_stop()
+        def b(event):
+            return block("NEEDS_WORK")
+
+        return bp
+
+    git = _git_repo(tmp_path)
+    (tmp_path / "a.txt").write_text("dirty")
+
+    # commit_on_stop BEFORE the gate -> commits even though the gate blocks
+    app = HookApp()
+    app.include(commit_on_stop())
+    app.include(blocker())
+    r = TestClient(app).send(MockEvent.stop(cwd=str(tmp_path)))
+    assert r is not None and r.decision == "block"
+    assert len(git("log", "--oneline").stdout.strip().splitlines()) == 2  # committed
+
+    # commit_on_stop AFTER the gate -> block short-circuits, no commit
+    (tmp_path / "a.txt").write_text("dirty2")
+    app2 = HookApp()
+    app2.include(blocker())
+    app2.include(commit_on_stop())
+    TestClient(app2).send(MockEvent.stop(cwd=str(tmp_path)))
+    assert len(git("log", "--oneline").stdout.strip().splitlines()) == 2  # unchanged
 
 
 # ── Scaffolding ──────────────────────────────────────────────────────────────

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
 from rich.console import Console
 
 from fasthooks import HookApp
 from fasthooks.recipes import (
+    commit_on_stop,
     evaluator_gate,
     evidence_gate,
     heartbeat,
@@ -157,6 +159,48 @@ def test_heartbeat_writes_marker_and_is_passive(tmp_path):
     assert marker.exists()
     data = json.loads(marker.read_text())
     assert data["tool"] == "Bash" and data["ts"] > 0
+
+
+def _git_repo(tmp_path):
+    def git(*a):
+        return subprocess.run(["git", *a], cwd=tmp_path, capture_output=True, text=True)
+    git("init", "-q")
+    git("config", "user.email", "t@t")
+    git("config", "user.name", "t")
+    (tmp_path / "a.txt").write_text("v1")
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    return git
+
+
+def test_commit_on_stop_commits_tracked_changes(tmp_path):
+    git = _git_repo(tmp_path)
+    app = HookApp()
+    app.include(commit_on_stop())
+    c = TestClient(app)
+
+    # dirty tracked change -> stop auto-commits (and never blocks)
+    (tmp_path / "a.txt").write_text("v2")
+    assert c.send(MockEvent.stop(cwd=str(tmp_path))) is None
+    log = git("log", "--oneline").stdout.strip().splitlines()
+    assert len(log) == 2 and "session checkpoint" in log[0]
+
+    # clean -> no new commit
+    c.send(MockEvent.stop(cwd=str(tmp_path)))
+    assert len(git("log", "--oneline").stdout.strip().splitlines()) == 2
+
+    # untracked-only -> not committed (tracked-only, like cwc)
+    (tmp_path / "new.txt").write_text("x")
+    c.send(MockEvent.stop(cwd=str(tmp_path)))
+    assert len(git("log", "--oneline").stdout.strip().splitlines()) == 2
+    assert "new.txt" not in git("ls-files").stdout
+
+
+def test_commit_on_stop_silent_outside_git(tmp_path):
+    """A non-git dir must not crash or block — passive backstop."""
+    app = HookApp()
+    app.include(commit_on_stop())
+    assert TestClient(app).send(MockEvent.stop(cwd=str(tmp_path))) is None
 
 
 # ── Scaffolding ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Applies the "primitives as a pipeline, not a god-class strategy" thesis to `LongRunningStrategy`.

1. **Extract `commit_on_stop`** as the 6th harness recipe — a cwc-style auto-commit backstop on Stop (`git commit -am` of *tracked* changes, with a timestamped message). Passive: never blocks, fails silent (no git / nothing to commit / commit rejected). This was the **one reusable mechanism `LongRunningStrategy` had that no recipe covered**, so extracting it makes `include_recipes` an honest replacement.
2. **Deprecate `LongRunningStrategy`** — `DeprecationWarning` on construction + docstring + a docs banner, pointing at `include_recipes`. Kept (not deleted) for a migration window.

## What's deliberately dropped
The strategy also bundled opinionated **prompt** content — initializer/coding session routing, progress-file handoff. That's the god-class part we're moving away from; it is *not* ported. The deprecation message and docs say so: write your own `@app.on_session_start` context if you want it.

## The harness recipe suite is now complete
`kill_switch` · `steer` · `evidence_gate` · `evaluator_gate` · `heartbeat` · `commit_on_stop` — composable via `app.include(...)` or `include_recipes()`.

## Verification
- `commit_on_stop` verified against a real temp git repo: commits when tracked-dirty, no-op when clean, leaves untracked files alone, silent outside a repo.
- Deprecation warning asserted with `pytest.warns`.
- **708 tests pass**, ruff + mypy clean.

Closes the P4 thread (see HARNESS-PLAN.md). Remaining: P5 dashboard showcase (separate repo).